### PR TITLE
Fix MOHW parsers

### DIFF
--- a/backend/Parsers/mohw.py
+++ b/backend/Parsers/mohw.py
@@ -13,7 +13,20 @@ def parseMOHWTaoyuan() -> Tuple[HospitalID, AppointmentAvailability]:
 
 
 def parseMOHWMiaoli() -> Tuple[HospitalID, AppointmentAvailability]:
-    return parseMOHW(13, "reg2.mil.mohw.gov.tw", "CO23")
+    index = 13
+    available = (
+        parseMOHWPage("reg2.mil.mohw.gov.tw", "CO23")
+        or parseMOHWPage("reg2.mil.mohw.gov.tw", "CO11")
+        or parseMOHWPage("reg2.mil.mohw.gov.tw", "CO41")
+    )
+
+    # FIXME(medicalwei): maybe refactor AppointmentAvailability into a function?
+    return (
+        index,
+        AppointmentAvailability.AVAILABLE
+        if bool(available)
+        else AppointmentAvailability.UNAVAILABLE,
+    )
 
 
 def parseMOHWTaichung() -> Tuple[HospitalID, AppointmentAvailability]:

--- a/backend/Parsers/mohw.py
+++ b/backend/Parsers/mohw.py
@@ -66,7 +66,7 @@ def parseMOHWPage(hostname: str, div_dr: str) -> bool:
     inputs = soup.find_all("input")
     states = dict((x["name"], x["value"]) for x in inputs)
 
-    weeks = [x["value"] for x in soup.findAll("input", {"name": "RdBtnLstWeek"})]
+    weeks = [x["value"] for x in soup.find_all("input", {"name": "RdBtnLstWeek"})]
     weeks.pop(0)  # popping off the first page
 
     for week in weeks:

--- a/backend/Parsers/mohw.py
+++ b/backend/Parsers/mohw.py
@@ -81,16 +81,5 @@ def parseMOHWPage(hostname: str, div_dr: str) -> bool:
 def parseMOHWWeekPage(body: str) -> bool:
     soup = BeautifulSoup(body, "html.parser")
 
-    # get a list of possible days
-    lst = [
-        y.find_all(text=True)
-        for x in soup.find_all("tr")[1:4]
-        for y in x.find_all("td")[1:7]
-    ]
-
-    # the output of above list comprehension is follows:
-    # [[], ["name of doctor", " (reservation count)"], ["name of doctor", "額滿"], ...]
-    # the second one shows availability
-    lst = [x[1] for x in lst if len(x) != 0 and x[1] != "額滿"]
-
-    return len(lst) != 0
+    # return if there's any link found in the page
+    return bool(soup.find_all("a"))

--- a/backend/Parsers/mohw.py
+++ b/backend/Parsers/mohw.py
@@ -33,6 +33,10 @@ def parseMOHWTaichung() -> Tuple[HospitalID, AppointmentAvailability]:
     return parseMOHW(14, "www03.taic.mohw.gov.tw", "01CD")
 
 
+def parseMOHWNantou() -> Tuple[HospitalID, AppointmentAvailability]:
+    return parseMOHW(18, "netreg01.nant.mohw.gov.tw", "0220")
+
+
 def parseMOHWTaitung() -> Tuple[HospitalID, AppointmentAvailability]:
     return parseMOHW(28, "netreg01.tait.mohw.gov.tw", "0119")
 

--- a/backend/Parsers/mohw.py
+++ b/backend/Parsers/mohw.py
@@ -67,7 +67,13 @@ def parseMOHWPage(hostname: str, div_dr: str) -> bool:
     states = dict((x["name"], x["value"]) for x in inputs)
 
     weeks = [x["value"] for x in soup.find_all("input", {"name": "RdBtnLstWeek"})]
-    weeks.pop(0)  # popping off the first page
+
+    try:
+        weeks.pop(0)  # popping off the first page
+    except IndexError:
+        # the size of weeks might be zero, e.g. in Miaoli MOHW hospital the
+        # reservation calendar is not paged
+        return False
 
     for week in weeks:
         states["RdBtnLstWeek"] = week

--- a/data/hospitals.csv
+++ b/data/hospitals.csv
@@ -24,7 +24,7 @@
 12,新竹縣,東元綜合醫院,"家庭醫學科、感染
 科",(03)552-7000,"30268
 新竹縣竹北市縣政二路69號",https://w3.tyh.com.tw/WebRegList_Dept.aspx?d=55
-13,苗栗縣,衛生福利部苗栗醫院,家庭醫學科,(037)261-920,36054苗栗縣苗栗市為公路747號,https://reg2.mil.mohw.gov.tw/OINetReg/OINetReg.Reg/Reg_RegTable.aspx?HID=F&Way=Dept&DivDr=CO23&Date=&Noon=
+13,苗栗縣,衛生福利部苗栗醫院,家庭醫學科,(037)261-920,36054苗栗縣苗栗市為公路747號,https://reg2.mil.mohw.gov.tw/OINetReg/OINetReg.Reg/Reg_NetReg.aspx
 14,臺中市,衛生福利部臺中醫院,家庭醫學科,(04)2229-4411,40343臺中市西區三民路一段199號,https://www03.taic.mohw.gov.tw/OINetReg/OINetReg.Reg/Reg_RegTable.aspx?HID=F&Way=Dept&DivDr=01CD&Date=&Noon=
 15,臺中市,童綜合醫院梧棲院區,家庭醫學科,"(04)2658-1919
 轉4000","43503

--- a/data/hospitals.csv
+++ b/data/hospitals.csv
@@ -33,7 +33,7 @@
 17,南投縣,埔里基督醫院,感染科,(049)291-2151,南投縣埔里鎮鐵山路1號,http://web2.pch.org.tw/booking/Covid19Reg/Covid19Reg.aspx?InsType=1,kjcl
 18,南投縣,衛生福利部南投醫院,"家庭醫學科、感染
 科",(049)223-1150,"54062
-南投縣南投市復興路478號",
+南投縣南投市復興路478號",https://netreg01.nant.mohw.gov.tw/OINetReg/OINetReg.Reg/Reg_RegTable.aspx?HID=F&Way=Dept&DivDr=0220&Date=&Noon=
 19,雲林縣,臺大醫院雲林分院,家庭醫學科,(05)532-3911,64041雲林縣斗六市雲林路二段579號,https://reg.ntuh.gov.tw/WebAdministration/DoctorServiceQueryByDrName.aspx?HospCode=Y0&QueryName=%E4%B8%BB%E6%B2%BB%E9%86%AB%E5%B8%AB,kjcl
 20,嘉義市,天主教聖馬爾定醫院,健康檢查中心,(05)275-6000,60069嘉義市東區大雅路二段565號,http://www.stm.org.tw/new/listDetail.aspx?n_id=1059&me_id=12
 21,嘉義縣,嘉義長庚紀念醫院,家庭醫學科,(05)362-1000,61363嘉義縣朴子市嘉朴路西段6號,https://register.cgmh.org.tw/Department/6/60990E,kjcl


### PR DESCRIPTION
This PR provides 4 fixes and 1 style adjustment to the codebase.

1. There's not only `額滿` can indicate inability of reservation.  Sometimes there is `網掛不開放`, or just left with name of the doctors without the link.  Henceforth we should just check the existence of links.

2. In Miaoli MOHW hospital's reservation page, the calendar is shown in one page, and there is no week selection.  We should handle the exception just in case if we cannot get list of weeks.

3. In Miaoli MOHW hospital there are 3 calendars for non-sponsored COVID-19 vaccination.  We should handle all calendars and use the reservation index page instead of any of these calendars.

4. Add link and availability checks to MOHW Nantou.

5. Use `find_all` instead of `findAll` in bs4.