### PR TITLE
Re-add scraping functionality with command line flag.

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -18,7 +18,6 @@ import local_scraper
 from hospital_types import Hospital, HospitalID, AppointmentAvailability, ScrapedData
 
 
-
 redis_host: Optional[str] = os.environ.get("REDIS_HOST")
 redis_port: Optional[str] = os.environ.get("REDIS_PORT")
 redis_username: Optional[str] = os.environ.get("REDIS_USERNAME")

--- a/package.json
+++ b/package.json
@@ -18,12 +18,13 @@
     "sharp": "^0.28.1"
   },
   "scripts": {
-    "backend": "parcel build ./frontend/index.html; flask backend/app.py",
+    "backend": "parcel build ./frontend/index.html; cd backend; pipenv run python app.py --scrape",
     "build": "parcel build ./frontend/index.html",
-    "lint": "pipenv run black backend/*; yarn eslint frontend/*.jsx",
+    "fixpipenv": "pipenv lock --pre --clear",
     "frontend": "parcel serve ./frontend/index.html",
-    "tc": "pipenv run pyre; yarn flow",
-    "fixpipenv": "pipenv lock --pre --clear"
+    "lint": "pipenv run black backend/*; yarn eslint frontend/*.jsx",
+    "scrape": "cd backend; pipenv run python local_scraper.py",
+    "tc": "pipenv run pyre; yarn flow"
   },
   "dependencies": {
     "react": "^17.0.2",


### PR DESCRIPTION
Currently, the production server reads from a Redis database which is updated by another machine scraping. This proves to be difficult for developers to test with. This pull request: 

1. Adds a flag --scrape to `app.py`. 
2. Modifies `app.py` to run `local_scraper` code instead of reading from the Redis database if this flag is true.
3. Adds package.json flags to run with the scraper for `yarn backend`. 