### PR TITLE
Add support for building out government-paid vaccines. 

### DIFF
--- a/backend/Parsers/changgung_chiayi.py
+++ b/backend/Parsers/changgung_chiayi.py
@@ -1,10 +1,14 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import HospitalID, AppointmentAvailability
+from hospital_types import (
+    ScrapedData,
+    AppointmentAvailability,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_changgung_chiayi() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_changgung_chiayi() -> ScrapedData:
     r = requests.get(
         "https://register.cgmh.org.tw/Department/6/60990E",
         timeout=1,
@@ -12,10 +16,14 @@ def parse_changgung_chiayi() -> Tuple[HospitalID, AppointmentAvailability]:
     soup = BeautifulSoup(r.text, "html.parser")
     table = soup.find("table", {"class": "department-table"})
     links = table.find_all("a")
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(links)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         21,
-        AppointmentAvailability.AVAILABLE
-        if bool(links)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )

--- a/backend/Parsers/mohw.py
+++ b/backend/Parsers/mohw.py
@@ -1,18 +1,23 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import HospitalID, AppointmentAvailability
+from hospital_types import (
+    HospitalID,
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_mohw_keelung() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_keelung() -> ScrapedData:
     return parse_mohw(1, "netreg.kln.mohw.gov.tw", "0196")
 
 
-def parse_mohw_taoyuan() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_taoyuan() -> ScrapedData:
     return parse_mohw(10, "tyghnetreg.tygh.mohw.gov.tw", "0126")
 
 
-def parse_mohw_miaoli() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_miaoli() -> ScrapedData:
     index = 13
     available = (
         parse_mohw_page("reg2.mil.mohw.gov.tw", "CO23")
@@ -20,40 +25,47 @@ def parse_mohw_miaoli() -> Tuple[HospitalID, AppointmentAvailability]:
         or parse_mohw_page("reg2.mil.mohw.gov.tw", "CO41")
     )
 
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(available)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
+
     # FIXME(medicalwei): maybe refactor AppointmentAvailability into a function?
     return (
         index,
-        AppointmentAvailability.AVAILABLE
-        if bool(available)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )
 
 
-def parse_mohw_taichung() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_taichung() -> ScrapedData:
     return parse_mohw(14, "www03.taic.mohw.gov.tw", "01CD")
 
 
-def parse_mohw_nantou() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_nantou() -> ScrapedData:
     return parse_mohw(18, "netreg01.nant.mohw.gov.tw", "0220")
 
 
-def parse_mohw_taitung() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_taitung() -> ScrapedData:
     return parse_mohw(28, "netreg01.tait.mohw.gov.tw", "0119")
 
 
-def parse_mohw_kinmen() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw_kinmen() -> ScrapedData:
     return parse_mohw(29, "netreg.kmhp.mohw.gov.tw", "104A")
 
 
-def parse_mohw(
-    index: int, hostname: str, div_dr: str
-) -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_mohw(index: int, hostname: str, div_dr: str) -> ScrapedData:
     available = parse_mohw_page(hostname, div_dr)
-    return (
-        index,
-        AppointmentAvailability.AVAILABLE
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
         if bool(available)
         else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
+    return (
+        index,
+        availability,
     )
 
 

--- a/backend/Parsers/ntu_hsinchu.py
+++ b/backend/Parsers/ntu_hsinchu.py
@@ -1,10 +1,15 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import HospitalID, AppointmentAvailability
+from hospital_types import (
+    HospitalID,
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_ntu_hsinchu() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_ntu_hsinchu() -> ScrapedData:
     r = requests.get(
         "https://reg.ntuh.gov.tw/WebAdministration/VaccineRegPublic.aspx?Hosp=T4&RegionCode=",
         verify="../data/ntuh-gov-tw-chain.pem",
@@ -13,10 +18,11 @@ def parse_ntu_hsinchu() -> Tuple[HospitalID, AppointmentAvailability]:
     soup = BeautifulSoup(r.text, "html.parser")
     table = soup.find("table")
     links = table.find_all("a", string="掛號")
-    # PEP8 Style: if list is not empty, then there are appointments
-    return (
-        11,
-        AppointmentAvailability.AVAILABLE
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
         if bool(links)
         else AppointmentAvailability.UNAVAILABLE,
-    )
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
+    # PEP8 Style: if list is not empty, then there are appointments
+    return (11, availability)

--- a/backend/Parsers/ntu_taipei.py
+++ b/backend/Parsers/ntu_taipei.py
@@ -1,10 +1,15 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import HospitalID, AppointmentAvailability
+from hospital_types import (
+    HospitalID,
+    AppointmentAvailability,
+    HospitalAvailabilitySchema,
+    ScrapedData,
+)
 
 
-def parse_ntu_taipei() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_ntu_taipei() -> ScrapedData:
     r = requests.get(
         "https://reg.ntuh.gov.tw/WebAdministration/VaccineRegPublic.aspx?Hosp=T0&Reg=",
         verify="../data/ntuh-gov-tw-chain.pem",
@@ -13,10 +18,14 @@ def parse_ntu_taipei() -> Tuple[HospitalID, AppointmentAvailability]:
     soup = BeautifulSoup(r.text, "html.parser")
     table = soup.find("table")
     links = table.find_all("a", string="掛號")
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(links)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         3,
-        AppointmentAvailability.AVAILABLE
-        if bool(links)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )

--- a/backend/Parsers/ntu_yunlin.py
+++ b/backend/Parsers/ntu_yunlin.py
@@ -1,10 +1,15 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import HospitalID, AppointmentAvailability
+from hospital_types import (
+    HospitalID,
+    AppointmentAvailability,
+    HospitalAvailabilitySchema,
+    ScrapedData,
+)
 
 
-def parse_ntu_yunlin() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_ntu_yunlin() -> ScrapedData:
     r = requests.get(
         "https://reg.ntuh.gov.tw/WebAdministration/DoctorServiceQueryByDrName.aspx?HospCode=Y0&QueryName=%E4%B8%BB%E6%B2%BB%E9%86%AB%E5%B8%AB",
         verify="../data/ntuh-gov-tw-chain.pem",
@@ -13,10 +18,14 @@ def parse_ntu_yunlin() -> Tuple[HospitalID, AppointmentAvailability]:
     soup = BeautifulSoup(r.text, "html.parser")
     table = soup.find("table")
     links = table.find_all("a", string="掛號")
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(links)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         19,
-        AppointmentAvailability.AVAILABLE
-        if bool(links)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )

--- a/backend/Parsers/pch_nantou.py
+++ b/backend/Parsers/pch_nantou.py
@@ -1,10 +1,14 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import AppointmentAvailability
+from hospital_types import (
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_pch_nantou() -> Tuple[int, AppointmentAvailability]:
+def parse_pch_nantou() -> ScrapedData:
     r = requests.get(
         "http://web2.pch.org.tw/booking/Covid19Reg/Covid19Reg.aspx?InsType=1",
         timeout=1,
@@ -12,10 +16,14 @@ def parse_pch_nantou() -> Tuple[int, AppointmentAvailability]:
     soup = BeautifulSoup(r.text, "html.parser")
     selector = soup.find("select", {"id": "ddlSchd"})
     options = selector.find_all("option")
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(options)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         17,
-        AppointmentAvailability.AVAILABLE
-        if bool(options)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )

--- a/backend/Parsers/siaogang_kaohsiung.py
+++ b/backend/Parsers/siaogang_kaohsiung.py
@@ -1,10 +1,15 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import HospitalID, AppointmentAvailability
+from hospital_types import (
+    HospitalID,
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_siaogang_kaohsiung() -> Tuple[HospitalID, AppointmentAvailability]:
+def parse_siaogang_kaohsiung() -> ScrapedData:
     def has_no_appointments(option: BeautifulSoup) -> bool:
         option = option.text
         return int(option[option.find("數") + 2 :].split("-")[0]) == 0
@@ -18,10 +23,15 @@ def parse_siaogang_kaohsiung() -> Tuple[HospitalID, AppointmentAvailability]:
     options = select.find_all("option")
     options = list(filter(has_no_appointments, options))
 
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(options)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
+
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         23,
-        AppointmentAvailability.AVAILABLE
-        if bool(options)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )

--- a/backend/Parsers/tonyen_hsinchu.py
+++ b/backend/Parsers/tonyen_hsinchu.py
@@ -1,10 +1,14 @@
 from typing import Tuple, List, Any
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import AppointmentAvailability, ScrapedData
+from hospital_types import (
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_tonyen_hsinchu() -> Tuple[int, AppointmentAvailability]:
+def parse_tonyen_hsinchu() -> ScrapedData:
     r = requests.get(
         "https://w3.tyh.com.tw/WebRegList_Dept.aspx?d=55",
         timeout=2,
@@ -13,10 +17,11 @@ def parse_tonyen_hsinchu() -> Tuple[int, AppointmentAvailability]:
     table = soup.find("table", {"class": "today-table"})
     days = table.find_all("td", {"class": "table-day"})
     appointments = list(filter(lambda day: bool(day.find_all("a")), days))
-    # PEP8 Style: if list is not empty, then there are appointments
-    return (
-        12,
-        AppointmentAvailability.AVAILABLE
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
         if bool(appointments)
         else AppointmentAvailability.UNAVAILABLE,
-    )
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
+    # PEP8 Style: if list is not empty, then there are appointments
+    return (12, availability)

--- a/backend/Parsers/tzuchi_hualien.py
+++ b/backend/Parsers/tzuchi_hualien.py
@@ -1,10 +1,14 @@
 from typing import Tuple
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import AppointmentAvailability
+from hospital_types import (
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_tzuchi_hualien() -> Tuple[int, AppointmentAvailability]:
+def parse_tzuchi_hualien() -> ScrapedData:
     r = requests.get(
         "https://app.tzuchi.com.tw/tchw/opdreg/OpdTimeShow.aspx?Depart=%E8%87%AA%E8%B2%BBCOVID19%E7%96%AB%E8%8B%97%E9%A0%90%E7%B4%84&HospLoc=3",
         timeout=1,
@@ -12,10 +16,14 @@ def parse_tzuchi_hualien() -> Tuple[int, AppointmentAvailability]:
     soup = BeautifulSoup(r.text, "html.parser")
     table = soup.find("table", {"id": "example"})
     links = table.find_all("a")
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(links)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         27,
-        AppointmentAvailability.AVAILABLE
-        if bool(links)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )

--- a/backend/Parsers/tzuchi_taipei.py
+++ b/backend/Parsers/tzuchi_taipei.py
@@ -1,10 +1,14 @@
 from typing import Tuple, List, Any
 import requests
 from bs4 import BeautifulSoup
-from hospital_types import AppointmentAvailability, ScrapedData
+from hospital_types import (
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
-def parse_tzuchi_taipei() -> Tuple[int, AppointmentAvailability]:
+def parse_tzuchi_taipei() -> ScrapedData:
     r = requests.get(
         "https://reg-prod.tzuchi-healthcare.org.tw/tchw/HIS5OpdReg/OpdTimeShow?Pass=XD;0022",
         verify="../data/tzuchi-healthcare-org-tw-chain.pem",
@@ -14,12 +18,16 @@ def parse_tzuchi_taipei() -> Tuple[int, AppointmentAvailability]:
     table = soup.find("table", {"id": "MainContent_gvOpdList"})
     rows = table.find_all("tr", {"class": "OpdListD"})
     rows = list(filter(row_contains_appointment, rows))
+    availability: HospitalAvailabilitySchema = {
+        "self_paid": AppointmentAvailability.AVAILABLE
+        if bool(rows)
+        else AppointmentAvailability.UNAVAILABLE,
+        "government_paid": AppointmentAvailability.NO_DATA,
+    }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         8,
-        AppointmentAvailability.AVAILABLE
-        if bool(rows)
-        else AppointmentAvailability.UNAVAILABLE,
+        availability,
     )
 
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -8,7 +8,13 @@ from bs4 import BeautifulSoup
 
 # Project imports
 import local_scraper
-from hospital_types import Hospital, HospitalID, AppointmentAvailability, ScrapedData
+from hospital_types import (
+    Hospital,
+    HospitalID,
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 
 
 redis_host: Optional[str] = os.environ.get("REDIS_HOST")
@@ -42,7 +48,7 @@ def get_availability_from_server() -> List[ScrapedData]:
     def get_availability(
         hospital_id: int,
     ) -> Optional[ScrapedData]:
-        availability = r.get("hospital:" + str(hospital_id))
+        availability: str = r.get("hospital:" + str(hospital_id))
         if availability == "AppointmentAvailability.AVAILABLE":
             availability = AppointmentAvailability.AVAILABLE
         elif availability == "AppointmentAvailability.UNAVAILABLE":
@@ -71,7 +77,7 @@ def hospitalData() -> List[Hospital]:
         for row in reader:
             hospital_id = int(row["編號"])
             hospital_availability = (
-                availability[hospital_id].value
+                availability[hospital_id]["self_paid"].value
                 if hospital_id in availability
                 else AppointmentAvailability.NO_DATA.value
             )

--- a/backend/hospital_types.py
+++ b/backend/hospital_types.py
@@ -5,20 +5,21 @@ from enum import Enum
 HospitalID = int
 
 
-class AppointmentAvailability(Enum):
-    AVAILABLE = "Available"
-    UNAVAILABLE = "Unavailable"
-    NO_DATA = "No data"
+class AppointmentAvailability(str, Enum):
+    AVAILABLE: str = "Available"
+    UNAVAILABLE: str = "Unavailable"
+    NO_DATA: str = "No data"
 
 
 class Hospital(TypedDict):
     address: str
-    availability: AppointmentAvailability
     department: str
+    governmentPaidAvailability: AppointmentAvailability
     hospitalId: HospitalID
     location: str
     name: str
     phone: str
+    selfPaidAvailability: AppointmentAvailability
     website: str
 
 

--- a/backend/hospital_types.py
+++ b/backend/hospital_types.py
@@ -22,4 +22,9 @@ class Hospital(TypedDict):
     website: str
 
 
-ScrapedData = Tuple[int, AppointmentAvailability]
+class HospitalAvailabilitySchema(TypedDict):
+    self_paid: AppointmentAvailability
+    government_paid: AppointmentAvailability
+
+
+ScrapedData = Tuple[int, HospitalAvailabilitySchema]

--- a/backend/local_scraper.py
+++ b/backend/local_scraper.py
@@ -61,7 +61,7 @@ def get_hospital_availability() -> List[ScrapedData]:
     return list(filter(None, availability))
 
 
-def hello_redis() -> None:
+def scrape() -> None:
     """Example Hello Redis Program"""
 
     # step 3: create the Redis Connection object
@@ -96,4 +96,4 @@ def hello_redis() -> None:
 
 
 if __name__ == "__main__":
-    hello_redis()
+    scrape()

--- a/backend/local_scraper.py
+++ b/backend/local_scraper.py
@@ -1,7 +1,11 @@
 import redis, os
 from typing import TypedDict, Tuple, Dict, Callable, List, Any, Optional, NewType
 from enum import Enum
-from hospital_types import AppointmentAvailability, ScrapedData
+from hospital_types import (
+    AppointmentAvailability,
+    ScrapedData,
+    HospitalAvailabilitySchema,
+)
 from dotenv import load_dotenv
 
 

--- a/backend/local_scraper.py
+++ b/backend/local_scraper.py
@@ -84,9 +84,19 @@ def scrape() -> None:
         )
 
         def set_availability(
-            hospital_id: int, availability: AppointmentAvailability
+            hospital_id: int,
+            availability: HospitalAvailabilitySchema,
         ) -> None:
-            r.set("hospital:" + str(hospital_id), availability.__str__())
+            f: Callable[[AppointmentAvailability], str] = lambda x: x.__str__()
+            # pyre-fixme[6]: Pyre cannot detect that the objects here are AppointmentAvailability
+            primitive_availability = {k: f(v) for k, v in availability.items()}
+            print(primitive_availability)
+            r.hset(
+                "hospital_schema_2:" + str(hospital_id),
+                key=None,
+                value=None,
+                mapping=primitive_availability,
+            )
 
         availability = get_hospital_availability()
 

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -5,6 +5,7 @@ import Map from './Components/Map';
 import VaccineDataGrid from './Components/VaccineDataGrid';
 import Spinner from './Components/Spinner';
 import G0vbar from './Components/G0vbar';
+import strings from './Strings/App.json';
 
 import type { Locale } from './Types/Locale';
 import type { VaccineType } from './Types/VaccineType';
@@ -28,7 +29,7 @@ export default function App(): React.Node {
             <Map />
           </div>
         </div>
-        <h2 style={{ textAlign: 'center' }}>Vaccination Availability</h2>
+        <h2 style={{ textAlign: 'center' }}>{strings.vaccineAvailability[locale]}</h2>
         <div style={{ textAlign: 'center' }}>
           <form
             className="btn-group"
@@ -49,7 +50,7 @@ export default function App(): React.Node {
               className="btn btn-outline-primary"
               htmlFor="btnradio1"
             >
-              Self-Paid Vaccine Appointments
+              {strings.vaccineTypes.selfPaid[locale]}
             </label>
             <input
               type="radio"
@@ -64,7 +65,7 @@ export default function App(): React.Node {
               className="btn btn-outline-primary"
               htmlFor="btnradio2"
             >
-              Government-Paid Vaccine Appointments
+              {strings.vaccineTypes.governmentPaid[locale]}
             </label>
           </form>
         </div>

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -33,7 +33,7 @@ export default function App(): React.Node {
           <form
             className="btn-group"
             role="group"
-            aria-label="Basic outlined example"
+            aria-label="Select type of vaccination."
           >
             {/* eslint-disable jsx-a11y/label-has-associated-control */}
             <input

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -7,10 +7,12 @@ import Spinner from './Components/Spinner';
 import G0vbar from './Components/G0vbar';
 
 import type { Locale } from './Types/Locale';
+import type { VaccineType } from './Types/VaccineType';
 
 export default function App(): React.Node {
   const [rows, setRows] = React.useState([]);
   const [locale: Locale, setLocale] = React.useState('zh');
+  const [vaccineType: VaccineType, setVaccineType] = React.useState('SelfPaid');
   const url = './hospitals';
   fetch(url).then((data) => data.json()).then((res) => setRows(res));
   return (
@@ -27,8 +29,31 @@ export default function App(): React.Node {
           </div>
         </div>
         <h2 style={{ textAlign: 'center' }}>Vaccination Availability</h2>
+        <div style={{ textAlign: 'center' }}>
+          <div
+            className="btn-group"
+            role="group"
+            aria-label="Basic outlined example"
+          >
+            <button
+              type="button"
+              onClick={() => setVaccineType('SelfPaid')}
+              className="btn btn-outline-primary"
+            >
+              Self-Paid Vaccine
+            </button>
+            <button
+              type="button"
+              onClick={() => setVaccineType('GovernmentPaid')}
+              className="btn btn-outline-primary"
+            >
+              Government-Paid Vaccine
+            </button>
+          </div>
+        </div>
         {rows.length === 0 ? <Spinner />
-          : <VaccineDataGrid rows={rows} locale={locale} />}
+          : <VaccineDataGrid
+            vaccineType={vaccineType} rows={rows} locale={locale} />}
         <p><i>Created with love by a member of g0v, Taiwans civic tech community.</i></p>
       </div>
     </div>

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -52,8 +52,13 @@ export default function App(): React.Node {
           </div>
         </div>
         {rows.length === 0 ? <Spinner />
-          : <VaccineDataGrid
-            vaccineType={vaccineType} rows={rows} locale={locale} />}
+          : (
+            <VaccineDataGrid
+              vaccineType={vaccineType}
+              rows={rows}
+              locale={locale}
+            />
+          )}
         <p><i>Created with love by a member of g0v, Taiwans civic tech community.</i></p>
       </div>
     </div>

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -30,26 +30,43 @@ export default function App(): React.Node {
         </div>
         <h2 style={{ textAlign: 'center' }}>Vaccination Availability</h2>
         <div style={{ textAlign: 'center' }}>
-          <div
+          <form
             className="btn-group"
             role="group"
             aria-label="Basic outlined example"
           >
-            <button
-              type="button"
+            {/* eslint-disable jsx-a11y/label-has-associated-control */}
+            <input
+              type="radio"
+              className="btn-check"
+              name="btnradio"
+              id="btnradio1"
+              autoComplete="off"
               onClick={() => setVaccineType('SelfPaid')}
+              checked={vaccineType === 'SelfPaid'}
+            />
+            <label
               className="btn btn-outline-primary"
+              htmlFor="btnradio1"
             >
-              Self-Paid Vaccine
-            </button>
-            <button
-              type="button"
+              Self-Paid Vaccine Appointments
+            </label>
+            <input
+              type="radio"
+              className="btn-check"
+              name="btnradio"
+              id="btnradio2"
+              autoComplete="off"
               onClick={() => setVaccineType('GovernmentPaid')}
+              checked={vaccineType === 'GovernmentPaid'}
+            />
+            <label
               className="btn btn-outline-primary"
+              htmlFor="btnradio2"
             >
-              Government-Paid Vaccine
-            </button>
-          </div>
+              Government-Paid Vaccine Appointments
+            </label>
+          </form>
         </div>
         {rows.length === 0 ? <Spinner />
           : (

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -20,39 +20,44 @@ export default function VaccineDataGrid(
   const unavailableHospitals = rows.filter((row) => getAvailability(row) === 'Unavailable');
   const noDataHospitals = rows.filter((row) => getAvailability(row) === 'No data');
 
-  const makeCardGrid = (hospitals: Array<Hospital>, buttonText: string) => (
-    <div className="row row-cols-1 row-cols-md-4 g-3">
-      {hospitals.map((hospital) => (
-        <div className="col" key={hospital.hospitalId.toString()}>
-          <Card
-            address={hospital.address}
-            availability={getAvailability(hospital)}
-            buttonText={buttonText}
-            department={hospital.department}
-            hospitalId={hospital.hospitalId}
-            locale={locale}
-            location={hospital.location}
-            name={hospital.name}
-            phone={hospital.phone}
-            website={hospital.website}
-          />
-        </div>
-      ))}
-    </div>
-  );
+  const makeCardGrid = (hospitals: Array<Hospital>, buttonText: string) => (hospitals.length !== 0
+    ? (
+      <div className="row row-cols-1 row-cols-md-4 g-3">
+        {hospitals.map((hospital) => (
+          <div className="col" key={hospital.hospitalId.toString()}>
+            <Card
+              address={hospital.address}
+              availability={getAvailability(hospital)}
+              buttonText={buttonText}
+              department={hospital.department}
+              hospitalId={hospital.hospitalId}
+              locale={locale}
+              location={hospital.location}
+              name={hospital.name}
+              phone={hospital.phone}
+              website={hospital.website}
+            />
+          </div>
+        ))}
+      </div>
+    ) : (
+      <div style={{ textAlign: 'center' }}>
+        <p className="lead"><i>No hospitals.</i></p>
+      </div>
+    ));
   return (
     <div>
-      <div style={{marginTop: 20}}>
+      <div style={{ marginTop: 20 }}>
         <h3>{strings.hospitalsWithAppointmentsTitle[locale]}</h3>
         <p><i>{strings.hospitalsWithAppointmentsSubtitle[locale]}</i></p>
         {makeCardGrid(availableHospitals, strings.buttons.getAppointment[locale])}
       </div>
-      <div style={{marginTop: 20}}>
+      <div style={{ marginTop: 20 }}>
         <h3>{strings.hospitalsWithNoDataTitle[locale]}</h3>
         <p><i>{strings.hospitalsWithNoDataSubtitle[locale]}</i></p>
         {makeCardGrid(noDataHospitals, strings.buttons.visitWebsite[locale])}
       </div>
-      <div style={{marginTop: 20}}>
+      <div style={{ marginTop: 20 }}>
         <h3>{strings.hospitalsWithNoAppointmentsTitle[locale]}</h3>
         <p><i>{strings.hospitalsWithNoAppointmentsSubtitle[locale]}</i></p>
         {makeCardGrid(unavailableHospitals, strings.buttons.visitWebsite[locale])}

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -5,15 +5,20 @@ import strings from '../Strings/Table.json';
 
 import type { Locale } from '../Types/Locale';
 import type { Hospital } from '../Types/Hospital';
+import type { VaccineType } from '../Types/VaccineType';
+import type { Availability } from '../Types/Availability';
 
 export default function VaccineDataGrid(
-  props: { rows: Array<Hospital>, locale: Locale },
+  props: { rows: Array<Hospital>, locale: Locale, vaccineType: VaccineType },
 ): React.Node {
-  const { rows, locale } = props;
+  const { rows, locale, vaccineType } = props;
 
-  const availableHospitals = rows.filter((row) => row.selfPaidAvailability === 'Available');
-  const unavailableHospitals = rows.filter((row) => row.selfPaidAvailability === 'Unavailable');
-  const noDataHospitals = rows.filter((row) => row.selfPaidAvailability === 'No data');
+  const getAvailability: (Hospital) => Availability = (hospital) => (vaccineType === 'SelfPaid'
+    ? hospital.selfPaidAvailability : hospital.governmentPaidAvailability);
+
+  const availableHospitals = rows.filter((row) => getAvailability(row) === 'Available');
+  const unavailableHospitals = rows.filter((row) => getAvailability(row) === 'Unavailable');
+  const noDataHospitals = rows.filter((row) => getAvailability(row) === 'No data');
 
   const makeCardGrid = (hospitals: Array<Hospital>, buttonText: string) => (
     <div className="row row-cols-1 row-cols-md-4 g-3">
@@ -21,7 +26,7 @@ export default function VaccineDataGrid(
         <div className="col" key={hospital.hospitalId.toString()}>
           <Card
             address={hospital.address}
-            availability={hospital.selfPaidAvailability}
+            availability={getAvailability(hospital)}
             buttonText={buttonText}
             department={hospital.department}
             hospitalId={hospital.hospitalId}

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -1,7 +1,7 @@
 // @flow
 import * as React from 'react';
 import Card from './Card';
-import strings from '../Strings/Table.json';
+import strings from '../Strings/VaccineDataGrid.json';
 
 import type { Locale } from '../Types/Locale';
 import type { Hospital } from '../Types/Hospital';
@@ -42,7 +42,7 @@ export default function VaccineDataGrid(
       </div>
     ) : (
       <div style={{ textAlign: 'center' }}>
-        <p className="lead"><i>No hospitals.</i></p>
+        <p className="lead"><i>{strings.noHospitals[locale]}</i></p>
       </div>
     ));
   return (

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -11,9 +11,9 @@ export default function VaccineDataGrid(
 ): React.Node {
   const { rows, locale } = props;
 
-  const availableHospitals = rows.filter((row) => row.availability === 'Available');
-  const unavailableHospitals = rows.filter((row) => row.availability === 'Unavailable');
-  const noDataHospitals = rows.filter((row) => row.availability === 'No data');
+  const availableHospitals = rows.filter((row) => row.selfPaidAvailability === 'Available');
+  const unavailableHospitals = rows.filter((row) => row.selfPaidAvailability === 'Unavailable');
+  const noDataHospitals = rows.filter((row) => row.selfPaidAvailability === 'No data');
 
   const makeCardGrid = (hospitals: Array<Hospital>, buttonText: string) => (
     <div className="row row-cols-1 row-cols-md-4 g-3">
@@ -21,7 +21,7 @@ export default function VaccineDataGrid(
         <div className="col" key={hospital.hospitalId.toString()}>
           <Card
             address={hospital.address}
-            availability={hospital.availability}
+            availability={hospital.selfPaidAvailability}
             buttonText={buttonText}
             department={hospital.department}
             hospitalId={hospital.hospitalId}

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -42,15 +42,21 @@ export default function VaccineDataGrid(
   );
   return (
     <div>
-      <h3>{strings.hospitalsWithAppointmentsTitle[locale]}</h3>
-      <i>{strings.hospitalsWithAppointmentsSubtitle[locale]}</i>
-      {makeCardGrid(availableHospitals, strings.buttons.getAppointment[locale])}
-      <h3>{strings.hospitalsWithNoDataTitle[locale]}</h3>
-      <i>{strings.hospitalsWithNoDataSubtitle[locale]}</i>
-      {makeCardGrid(noDataHospitals, strings.buttons.visitWebsite[locale])}
-      <h3>{strings.hospitalsWithNoAppointmentsTitle[locale]}</h3>
-      <i>{strings.hospitalsWithNoAppointmentsSubtitle[locale]}</i>
-      {makeCardGrid(unavailableHospitals, strings.buttons.visitWebsite[locale])}
+      <div style={{marginTop: 20}}>
+        <h3>{strings.hospitalsWithAppointmentsTitle[locale]}</h3>
+        <p><i>{strings.hospitalsWithAppointmentsSubtitle[locale]}</i></p>
+        {makeCardGrid(availableHospitals, strings.buttons.getAppointment[locale])}
+      </div>
+      <div style={{marginTop: 20}}>
+        <h3>{strings.hospitalsWithNoDataTitle[locale]}</h3>
+        <p><i>{strings.hospitalsWithNoDataSubtitle[locale]}</i></p>
+        {makeCardGrid(noDataHospitals, strings.buttons.visitWebsite[locale])}
+      </div>
+      <div style={{marginTop: 20}}>
+        <h3>{strings.hospitalsWithNoAppointmentsTitle[locale]}</h3>
+        <p><i>{strings.hospitalsWithNoAppointmentsSubtitle[locale]}</i></p>
+        {makeCardGrid(unavailableHospitals, strings.buttons.visitWebsite[locale])}
+      </div>
     </div>
   );
 }

--- a/frontend/Strings/App.json
+++ b/frontend/Strings/App.json
@@ -1,0 +1,16 @@
+{
+  "vaccineAvailability": {
+    "en": "Vaccine Availability",
+    "zh": "疫苗資訊"
+  },
+  "vaccineTypes": {
+    "governmentPaid": {
+      "en": "Government-Paid Vaccinations",
+      "zh": "公費疫苗"
+    },
+    "selfPaid": {
+      "en": "Self-Paid Vaccinations",
+      "zh": "自費疫苗"
+    }
+  }
+}

--- a/frontend/Strings/VaccineDataGrid.json
+++ b/frontend/Strings/VaccineDataGrid.json
@@ -23,6 +23,10 @@
     "en": "These hospitals have no appointments. Please check again later.",
     "zh": "這些醫院沒有自費疫苗接種名額。請稍後在查詢本網站"
   },
+  "noHospitals": {
+    "en": "No hospitals in this category.",
+    "zh": "該種類無醫院"
+  },
   "buttons": {
     "getAppointment": {
       "en": "Get Appointment",

--- a/frontend/Types/Hospital.js
+++ b/frontend/Types/Hospital.js
@@ -3,12 +3,13 @@ import type { Availability } from './Availability';
 import type { Location } from './Location';
 
 export type Hospital = {|
-    hospitalId: Number,
-    name: string,
-    location: Location,
-    department: string,
-    phone: string,
     address: string,
+    department: string,
+    governmentPaidAvailability: Availability,
+    hospitalId: Number,
+    location: Location,
+    name: string,
+    phone: string,
+    selfPaidAvailability: Availability,
     website: string,
-    availability: Availability,
   |};

--- a/frontend/Types/VaccineType.js
+++ b/frontend/Types/VaccineType.js
@@ -1,0 +1,3 @@
+// @flow
+
+export type VaccineType = 'SelfPaid' | 'GovernmentPaid';


### PR DESCRIPTION
# Context
We should add support for searching for and booking vaccine appointments.

# This PR: 
1. Modifies the Python types to take in two different types of AppointmentAvailability.
2. Feeds this into the Redis database. 
3. Reads it from the Redis database and displays to the user. We've added two different radio buttons to let the user choose between self-paid and government-paid vaccinations. 

# Test Plan: 
Since we're modifying the infra here, we need to test that reading from redis and local scraping works correctly. 
1. Confirm `cd backend; pipenv run python local_scraper.py` runs without error.
2. Confirm `cd backend; pipenv run python app.py` runs without error.
3. Confirm `cd backend; yarn backend` runs without error. 