### PR TITLE
Add support for government-paid hospitals from NTUH Yunlin

### DIFF
--- a/backend/Parsers/ntu_yunlin.py
+++ b/backend/Parsers/ntu_yunlin.py
@@ -8,24 +8,49 @@ from hospital_types import (
     ScrapedData,
 )
 
+CERT: str = "../data/ntuh-gov-tw-chain.pem"
+
 
 def parse_ntu_yunlin() -> ScrapedData:
-    r = requests.get(
-        "https://reg.ntuh.gov.tw/WebAdministration/DoctorServiceQueryByDrName.aspx?HospCode=Y0&QueryName=%E4%B8%BB%E6%B2%BB%E9%86%AB%E5%B8%AB",
-        verify="../data/ntuh-gov-tw-chain.pem",
-        timeout=2,
-    )
-    soup = BeautifulSoup(r.text, "html.parser")
-    table = soup.find("table")
-    links = table.find_all("a", string="掛號")
     availability: HospitalAvailabilitySchema = {
-        "self_paid": AppointmentAvailability.AVAILABLE
-        if bool(links)
-        else AppointmentAvailability.UNAVAILABLE,
-        "government_paid": AppointmentAvailability.NO_DATA,
+        "self_paid": parse_ntu_yunlin_self_paid(),
+        "government_paid": parse_ntu_yunlin_gov_paid(),
     }
     # PEP8 Style: if list is not empty, then there are appointments
     return (
         19,
         availability,
+    )
+
+
+def parse_ntu_yunlin_self_paid() -> AppointmentAvailability:
+    r = requests.get(
+        "https://reg.ntuh.gov.tw/WebAdministration/DoctorServiceQueryByDrName.aspx?HospCode=Y0&QueryName=%E4%B8%BB%E6%B2%BB%E9%86%AB%E5%B8%AB",
+        verify=CERT,
+        timeout=2,
+    )
+    soup = BeautifulSoup(r.text, "html.parser")
+    table = soup.find("table")
+    links = table.find_all("a", string="掛號")
+    return (
+        AppointmentAvailability.AVAILABLE
+        if bool(links)
+        else AppointmentAvailability.UNAVAILABLE
+    )
+
+
+def parse_ntu_yunlin_gov_paid() -> AppointmentAvailability:
+    r = requests.get(
+        "https://reg.ntuh.gov.tw/WebAdministration/VaccineClinicReg.aspx?Hosp=Y0&Reg=",
+        verify=CERT,
+        timeout=2,
+    )
+    soup = BeautifulSoup(r.text, "html.parser")
+    radio_buttons = soup.find("span", {"id": "rbl_Clinic"})
+    appointments = radio_buttons.find_all("input")
+    appointments = list(filter(lambda tag: not tag.has_attr("disabled"), appointments))
+    return (
+        AppointmentAvailability.AVAILABLE
+        if bool(appointments)
+        else AppointmentAvailability.UNAVAILABLE
     )

--- a/backend/local_scraper.py
+++ b/backend/local_scraper.py
@@ -61,9 +61,7 @@ PARSERS: List[Callable[[], Optional[ScrapedData]]] = [
 
 
 def get_hospital_availability() -> List[ScrapedData]:
-    availability: List[ScrapedData] = list(
-        filter(None, [f() for f in PARSERS])
-    )
+    availability: List[ScrapedData] = list(filter(None, [f() for f in PARSERS]))
     as_dict: Dict[int, HospitalAvailabilitySchema] = dict(availability)
     for i in range(1, 32):
         if i in as_dict:

--- a/data/hospitals.csv
+++ b/data/hospitals.csv
@@ -34,7 +34,7 @@
 18,南投縣,衛生福利部南投醫院,"家庭醫學科、感染
 科",(049)223-1150,"54062
 南投縣南投市復興路478號",https://netreg01.nant.mohw.gov.tw/OINetReg/OINetReg.Reg/Reg_RegTable.aspx?HID=F&Way=Dept&DivDr=0220&Date=&Noon=
-19,雲林縣,臺大醫院雲林分院,家庭醫學科,(05)532-3911,64041雲林縣斗六市雲林路二段579號,https://reg.ntuh.gov.tw/WebAdministration/DoctorServiceQueryByDrName.aspx?HospCode=Y0&QueryName=%E4%B8%BB%E6%B2%BB%E9%86%AB%E5%B8%AB,kjcl
+19,雲林縣,臺大醫院雲林分院,家庭醫學科,(05)532-3911,64041雲林縣斗六市雲林路二段579號,https://web.ylh.gov.tw/covid-19/,kjcl
 20,嘉義市,天主教聖馬爾定醫院,健康檢查中心,(05)275-6000,60069嘉義市東區大雅路二段565號,http://www.stm.org.tw/new/listDetail.aspx?n_id=1059&me_id=12
 21,嘉義縣,嘉義長庚紀念醫院,家庭醫學科,(05)362-1000,61363嘉義縣朴子市嘉朴路西段6號,https://register.cgmh.org.tw/Department/6/60990E,kjcl
 22,臺南市,成大醫院,家庭醫學科,"(06)235-3535


### PR DESCRIPTION
# Context
We are building out crawlers to crawl data from Yunlin Hospital. 

# This PR
Adds a scraper for hospital appointments from Yunlin Hospital. 

# Test Plan:
> cd backend;
> pipenv run python
> from Parsers.ntu_yunlin import *
> parse_ntu_yunlin_gov_paid()
AppointmentAvailability.UNAVAILABLE

Expect no appointments because currently there are none. 