### PR TITLE
Add content indicating no more self-paid vaccines.

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -94,7 +94,7 @@ async def hospitalData() -> List[Hospital]:
             hospital_id = int(row["編號"])
             hospital: Hospital = {
                 "address": row["地址"],
-                "selfPaidAvailability": availability[hospital_id]["self_paid"],
+                "selfPaidAvailability": AppointmentAvailability.UNAVAILABLE,
                 "department": row["科別"],
                 "governmentPaidAvailability": availability[hospital_id][
                     "government_paid"

--- a/frontend/Components/Content.jsx
+++ b/frontend/Components/Content.jsx
@@ -7,9 +7,13 @@ import type { Locale } from '../Types/Locale';
 const enUS = `
 ### Who can get the COVID-19 vaccine?
 You can get the COVID-19 vaccine for free if you are part of
-the eligible groups set by the Taiwanese government. If you
-intend to travel outside of Taiwan, you may pay out-of-pocket
-for a vaccine.
+the eligible groups set by the Taiwanese government. 
+
+## Are there self-paid vaccines available? 
+Self-paid vaccines were available for those who intended to travel
+abroad. This program was ended by the CECC on May 15, 2021. 
+If you previously got your first dose through this program, you
+can schedule your second shot directly with your hospital. 
 
 ### What vaccines are available? 
 Currently, the Taiwanese government is administering the
@@ -43,6 +47,10 @@ const zhTW = `
 COVID-19 公費疫苗已開放給公費疫苗接種對象。詳細資料請參考
 [衛生福利部疾病管理署官網](https://www.cdc.gov.tw/Category/Page/9mcqWyq51P_aYADuh3rTBA)。
 此外，COVID-19 自費疫苗也開放給任何有出國需求在台的人。接種對象不限國籍。
+
+### 有 COVID-19 自費疫苗嗎？
+根據指揮中心5月15號的記者會，現在無法註冊自費疫苗名額。如果您已經接種第一劑疫苗的話
+可直接聯絡醫院預約接種第二劑疫苗。
 
 ### 現在能夠打哪一種疫苗？
 疾病管理署正在供應 AstraZeneca 的疫苗。

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -48,6 +48,18 @@ export default function VaccineDataGrid(
     ));
   return (
     <div>
+      <div style={{ display: 'flex', justifyContent: 'center' }}>
+        <div style={{ textAlign: 'center', maxWidth: 800 }}>
+          <p>
+            <b>
+              {strings.selfPaidVaccineClosure.notice[locale]}
+            </b>
+          </p>
+          <p>
+            {strings.selfPaidVaccineClosure.selfPaid2ndShot[locale]}
+        </p>
+        </div>
+      </div>
       <div style={{ marginTop: 20 }}>
         <h3>{strings.hospitalsWithAppointmentsTitle[locale]}</h3>
         <p>

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -48,18 +48,22 @@ export default function VaccineDataGrid(
     ));
   return (
     <div>
-      <div style={{ display: 'flex', justifyContent: 'center' }}>
-        <div style={{ textAlign: 'center', maxWidth: 800 }}>
-          <p>
-            <b>
-              {strings.selfPaidVaccineClosure.notice[locale]}
-            </b>
-          </p>
-          <p>
-            {strings.selfPaidVaccineClosure.selfPaid2ndShot[locale]}
-        </p>
-        </div>
-      </div>
+      {
+        vaccineType === 'SelfPaid' ? (
+          <div style={{ display: 'flex', justifyContent: 'center' }}>
+            <div style={{ textAlign: 'center', maxWidth: 800 }}>
+              <p>
+                <b>
+                  {strings.selfPaidVaccineClosure.notice[locale]}
+                </b>
+              </p>
+              <p>
+                {strings.selfPaidVaccineClosure.selfPaid2ndShot[locale]}
+              </p>
+            </div>
+          </div>
+        ) : null
+      }
       <div style={{ marginTop: 20 }}>
         <h3>{strings.hospitalsWithAppointmentsTitle[locale]}</h3>
         <p>

--- a/frontend/Strings/VaccineDataGrid.yaml
+++ b/frontend/Strings/VaccineDataGrid.yaml
@@ -39,3 +39,10 @@ buttons:
   visitWebsite:
     en: Visit Hospital Website
     zh: 前往醫院官網查詢
+selfPaidVaccineClosure:
+  notice: 
+    en: As of Saturday, May 15, under new CECC directives, the self-paid vaccination program is now closed.
+    zh: 根據指揮中心2021年5月15日的記者會，現在無法註冊自費疫苗名額。
+  selfPaid2ndShot: 
+    en: Those who received a first dose are eligible for second appointments and should contact hospitals to schedule their second dose directly. Stay home and save lives. 天佑台灣！
+    zh: 如果您已經接種第一劑疫苗的話可直接聯絡醫院預約接種第二劑疫苗。


### PR DESCRIPTION
Self-paid vaccines program was cancelled by the CECC on May 15, 2021. Updating website content in English and Mandarin to reflect this. 
# This PR: 
![Screenshot from 2021-05-15 18-39-04](https://user-images.githubusercontent.com/8745371/118357454-e40d2080-b5ac-11eb-913d-e085120fb2a9.png)
Adds a notice to the self-paid vaccination area indicating it's over. 
![Screenshot from 2021-05-15 18-39-11](https://user-images.githubusercontent.com/8745371/118357456-e53e4d80-b5ac-11eb-9205-ea8add55bc90.png)
By-default sets all self-paid appointment availability to UNAVAILABLE instead of basing it off parsed data. 
![Screenshot from 2021-05-15 18-39-16](https://user-images.githubusercontent.com/8745371/118357459-e5d6e400-b5ac-11eb-9a3f-4d4304af8d01.png)
Amends the content on the website to reflect this change. 


