### PR TITLE
Containerization for web server and scraper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.parcel-cache
+.vscode
+dist
+node_modules
+stubs
+.github
+docker

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Collecting all the information about self-paid vaccines in Taiwan. 
 
 ## Set up project
-Make sure you have [pipenv](https://pypi.org/project/pipenv/) installed. 
+Make sure you have [pipenv](https://pypi.org/project/pipenv/) and [yarn](https://yarnpkg.com/getting-started/install) installed.
 1. git clone the repository
 2. run `pipenv install`.
 3. run `yarn`
@@ -55,6 +55,14 @@ When you are developing locally, instead of reading from the Redis server, it ma
 6. Make a Pull Request and tag @kevinjcliao to take a look. 
 
 See [here](https://github.com/g0v/vaccinate/pull/1) for an example of a Pull Request. 
+
+## Run Locally
+
+You may use Docker to run web server and scraper locally in production mode.
+
+```
+docker compose up
+```
 
 ## Known Issues
 * After adding a new Python dependency, pipenv gets pretty unhappy. Run `pipenv lock --pre --clear` to fix. I've aliased this to `yarn fixpipenv`.

--- a/backend/app.py
+++ b/backend/app.py
@@ -21,6 +21,7 @@ redis_host: Optional[str] = os.environ.get("REDIS_HOST")
 redis_port: Optional[str] = os.environ.get("REDIS_PORT")
 redis_username: Optional[str] = os.environ.get("REDIS_USERNAME")
 redis_password: Optional[str] = os.environ.get("REDIS_PASSWORD")
+redis_ssl: Optional[bool] = (os.environ.get("REDIS_SSL") != "no") # default is true means to use SSL
 
 
 app = Flask(
@@ -40,7 +41,7 @@ def get_availability_from_server() -> List[ScrapedData]:
         password=redis_password,
         decode_responses=True,
         username=redis_username,
-        ssl=True,
+        ssl=redis_ssl,
     )
 
     hospital_ids = list(range(1, 32))

--- a/backend/app.py
+++ b/backend/app.py
@@ -87,7 +87,6 @@ async def hospitalData() -> List[Hospital]:
     else:
         availability = dict(get_availability_from_server())
 
-    app.logger.warning(availability)
     with open("../data/hospitals.csv") as csvfile:
         reader = csv.DictReader(csvfile)
         rows = []

--- a/backend/local_scraper.py
+++ b/backend/local_scraper.py
@@ -35,7 +35,7 @@ redis_host: Optional[str] = os.environ.get("REDIS_HOST")
 redis_port: Optional[str] = os.environ.get("REDIS_PORT")
 redis_username: Optional[str] = os.environ.get("REDIS_USERNAME")
 redis_password: Optional[str] = os.environ.get("REDIS_PASSWORD")
-
+redis_ssl: Optional[bool] = (os.environ.get("REDIS_SSL") != "no") # default is true means to use SSL
 
 def error_boundary(
     f: Callable[[], Coroutine[Any, Any, ScrapedData]]
@@ -108,7 +108,7 @@ async def scrape() -> None:
             decode_responses=True,
             username=redis_username,
             socket_timeout=10,
-            ssl=True,
+            ssl=redis_ssl,
         )
 
         def set_availability(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: "3.8"
+
+services:
+  web:
+    build:
+      dockerfile: ./docker/web/Dockerfile
+      context: .
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_USERNAME: ""
+      REDIS_PASSWORD: ""
+      REDIS_SSL: "no"
+    ports:
+      - 5000:5000
+
+  scraper:
+    build:
+      dockerfile: ./docker/scraper/Dockerfile
+      context: .
+    environment:
+      REDIS_HOST: redis
+      REDIS_PORT: 6379
+      REDIS_USERNAME: ""
+      REDIS_PASSWORD: ""
+      REDIS_SSL: "no"
+
+  redis:
+    image: redis:6
+    ports:
+      - 6379:6379

--- a/docker/scraper/Dockerfile
+++ b/docker/scraper/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+RUN pip install pipenv
+
+COPY Pipfile* /app/
+RUN pipenv install
+
+COPY . /app
+
+# TODO: cron job this
+CMD ["pipenv", "run", "python", "/app/backend/local_scraper.py"]

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,30 @@
+FROM node:lts as build_react
+
+WORKDIR /app
+
+COPY package.json yarn.lock /app/
+RUN yarn install
+
+COPY . /app
+RUN yarn build
+
+# -----------------8<----------------------
+
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+COPY --from=build_react /app/dist /app/dist
+
+RUN pip install pipenv
+
+COPY Pipfile* /app/
+RUN pipenv install
+
+COPY . /app
+
+# FIXME: some paths are CWD-sensitive, e.g. reading '../data/hospitals.csv'
+WORKDIR /app/backend
+
+# FIXME: error message says I'm using a non-production-ready server.
+CMD ["pipenv", "run", "python", "/app/backend/app.py"]


### PR DESCRIPTION
This is the first step to continuously deployment.

This patch introduces two Dockerfiles:

- `docker/web/Dockerfile` = web server (front & backend)
- `docker/scraper/Dockerfile` = scraper. (TODO: cron job)

They both have to connect to a shared Redis server.

This patch also introduces a local `docker-compose.yml` for development. The existing code connects to Redis using TLS, however this is very hard and probably unnecessary for local development, so I introduced an env var `REDIS_SSL=no` to disable it (defaults to `yes` means using SSL)

The next step after this is to deploy web server using a Docker image. This will involve GitHub Actions -> Docker Hub Registry -> [Digital Ocean Deployment](https://docs.digitalocean.com/products/app-platform/how-to/deploy-from-registry/).

Note that due to my lack of knowledge in Flask I was unable to dismiss the following message. Please feel free to fix it or let me know what's the proper way to run a Python web server:

```
web_1      |  * Environment: production
web_1      |    WARNING: This is a development server. Do not use it in a production deployment.
web_1      |    Use a production WSGI server instead.
web_1      |  * Debug mode: on
web_1      |  * Running on all addresses.
web_1      |    WARNING: This is a development server. Do not use it in a production deployment.
```