### PR TITLE
Docker for scraper

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.parcel-cache
+.vscode
+dist
+node_modules
+stubs
+.github
+docker
+__pycache__

--- a/backend/local_scraper.py
+++ b/backend/local_scraper.py
@@ -1,4 +1,5 @@
-import redis, os
+import argparse
+import redis, os, json
 from typing import TypedDict, Tuple, Dict, Callable, List, Any, Optional, NewType
 from enum import Enum
 from hospital_types import (
@@ -29,27 +30,6 @@ from Parsers.ncku_tainan import *
 from Parsers.kmuh_kaohsiung import *
 from Parsers.sanjunzong_penghu import *
 
-load_dotenv()
-
-redis_host: Optional[str] = os.environ.get("REDIS_HOST")
-redis_port: Optional[str] = os.environ.get("REDIS_PORT")
-redis_username: Optional[str] = os.environ.get("REDIS_USERNAME")
-redis_password: Optional[str] = os.environ.get("REDIS_PASSWORD")
-
-
-# The decode_repsonses flag here directs the client to convert the responses from Redis into Python strings
-# using the default encoding utf-8.  This is client specific.
-r: redis.StrictRedis = redis.StrictRedis(
-    host=redis_host,
-    port=redis_port,
-    password=redis_password,
-    decode_responses=True,
-    username=redis_username,
-    socket_timeout=10,
-    ssl=True,
-)
-
-
 def error_boundary(
     s: Scraper,
 ) -> Callable[[], Coroutine[Any, Any, Optional[ScrapedData]]]:
@@ -67,23 +47,15 @@ def error_boundary(
 
 
 def make_uploader(s: Scraper) -> Callable[[], Coroutine[Any, Any, HospitalID]]:
-    async def scrape_and_upload() -> HospitalID:
+    async def scrape_and_upload() -> [HospitalID, dict]:
         scraper = error_boundary(s)
         result = await scraper()
         if not result:
-            return ""
+            return None
         (hospital_id, availability) = result
-        primitive_availability = {k: v.__str__() for k, v in availability.items()}
+        primitive_availability = {k: v.value for k, v in availability.items()}
 
-        print(primitive_availability)
-        r.hset(
-            "hospital_schema_3:" + str(hospital_id),
-            key=None,
-            value=None,
-            # pyre-fixme[6]: Pyre cannot make Dict[str, str] compatible with their HSet type.
-            mapping=primitive_availability,
-        )
-        return s.hospital_id
+        return (hospital_id, primitive_availability)
 
     return scrape_and_upload
 
@@ -110,11 +82,6 @@ PARSERS: List[Scraper] = [
 ]
 
 
-async def scrape() -> None:
-    """Example Hello Redis Program"""
-    await asyncio.gather(*[make_uploader(p)() for p in PARSERS])
-
-
 async def get_hospital_availability() -> Dict[HospitalID, HospitalAvailabilitySchema]:
     return dict(
         filter(
@@ -122,7 +89,67 @@ async def get_hospital_availability() -> Dict[HospitalID, HospitalAvailabilitySc
         )
     )
 
+def send_to_redis(r: redis.StrictRedis, hospital_id: str, availability: HospitalAvailabilitySchema) -> None:
+    primitive_availability = {k: v.__str__() for k, v in availability.items()}
+
+    r.hset(
+        "hospital_schema_3:" + str(hospital_id),
+        key=None,
+        value=None,
+        # pyre-fixme[6]: Pyre cannot make Dict[str, str] compatible with their HSet type.
+        mapping=primitive_availability,
+    )
+
+    return
 
 if __name__ == "__main__":
-    asyncio.run(scrape())
+    parser = argparse.ArgumentParser(
+        description="Scrapes availability from hospitals"
+    )
+    parser.add_argument(
+        "--redis",
+        action="store_true",
+        default=False,
+        help="""Send results to a Redis server. Server info can be overriden with env vars:
+            REDIS_HOST=localhost,
+            REDIS_PORT=6379,
+            REDIS_USERNAME="",
+            REDIS_PASSWORD="",
+            REDIS_SSL="yes" (Set to "no" for non-SSL connection)
+        """,
+    )
+
+    parser.add_argument("--out", help="Output JSON to a file.")
+
+    flag_values: argparse.Namespace = parser.parse_args()
+
+    load_dotenv()
+    data = asyncio.run(get_hospital_availability())
+    print(data)
+
+    any_error = False
+
+    if flag_values.redis:
+        r = redis.StrictRedis(
+            host=os.environ.get("REDIS_HOST") or "localhost",
+            port=os.environ.get("REDIS_PORT") or "6379",
+            username=os.environ.get("REDIS_USERNAME") or "",
+            password=os.environ.get("REDIS_PASSWORD") or "",
+            ssl=(os.environ.get("REDIS_SSL") != "no"),
+            socket_timeout=10
+        )
+
+        print("Sending result to Redis...")
+
+        try:
+            for hospital_id, availability in data.items():
+                send_to_redis(r, hospital_id, availability)
+        except Exception as e:
+            print("Failed to send to Redis:", type(e).__name__, "-", e)
+            any_error = True
+
+    if flag_values.out != None:
+        with open(flag_values.out, 'w') as fout:
+            print(json.dumps(data, indent=2), file=fout)
+
     print("--- %s seconds ---" % (time.time() - START_TIME))

--- a/docker/scraper/Dockerfile
+++ b/docker/scraper/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.8-slim-buster
+
+WORKDIR /app
+
+RUN pip install pipenv
+
+COPY Pipfile* /app/
+RUN pipenv install
+
+COPY backend/Parsers/* /app/backend/Parsers/
+COPY backend/hospital_types.py /app/backend/
+COPY backend/local_scraper.py /app/backend/
+COPY scraper.sh /app/
+
+CMD ["/"]

--- a/scraper.sh
+++ b/scraper.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# This wrapper is mostly useful for Docker
+
+pipenv run python ./backend/local_scraper.py "$@"


### PR DESCRIPTION
This patch tries to make scraper a standalone Docker image.

Specifically:

1. `local_scraper.py` can now output to JSON using `--out=file.json` arg.
2. `local_scraper.py` can still store results to Redis, but needs `--redis` arg (breaking change!!)
    - env vars remain same, but I added `REDIS_SSL` flag env var for local testing. Default to `yes`; set to `no` to disable SSL.

My next plan:

1. Run this Docker image on AWS ECS as a periodic task, then send the result to S3.
2. Developer can run this script without setting up a Redis instance locally. Faster iteration.
3. Eventually, frontend can download live data from S3 (maybe add a CDN in front), to eliminate backend completely.

Note that this PR replaces my previous PR #55, which is too aggressive to be useful.