### PR TITLE
Hospital Grid By City

### DIFF
--- a/frontend/Components/Navbar.jsx
+++ b/frontend/Components/Navbar.jsx
@@ -8,6 +8,8 @@ import {
 
 export default function Navbar(): React.Node {
   const [t] = useTranslation('nav');
+  const [isShown, setIsShown] = React.useState(false);
+  const navBarShown = isShown ? "collapse navbar-collapse show" : "collapse navbar-collapse";
 
   return (
     <nav className="navbar navbar-expand-lg navbar-light bg-light sticky-top">
@@ -21,10 +23,11 @@ export default function Navbar(): React.Node {
           aria-controls="navbarNavAltMarkup"
           aria-expanded="false"
           aria-label="Toggle navigation"
+          onClick={() => setIsShown(!isShown)}
         >
           <span className="navbar-toggler-icon" />
         </button>
-        <div className="collapse navbar-collapse" id="navbarNavAltMarkup">
+        <div className={navBarShown} id="navbarNavAltMarkup">
           <div className="navbar-nav">
             <NavLink
               exact

--- a/frontend/Components/Navbar.jsx
+++ b/frontend/Components/Navbar.jsx
@@ -9,7 +9,7 @@ import {
 export default function Navbar(): React.Node {
   const [t] = useTranslation('nav');
   const [isShown, setIsShown] = React.useState(false);
-  const navBarShown = isShown ? "collapse navbar-collapse show" : "collapse navbar-collapse";
+  const navBarShown = isShown ? 'collapse navbar-collapse show' : 'collapse navbar-collapse';
 
   return (
     <nav className="navbar navbar-expand-lg navbar-light bg-light sticky-top">

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -2,6 +2,8 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
 import Card from './Card';
+import Accordion from './VaccineDataGrid/Accordion';
+import AccordionItem from './VaccineDataGrid/AccordionItem';
 
 import type { Hospital } from '../Types/Hospital';
 import type { VaccineType } from '../Types/VaccineType';
@@ -34,7 +36,7 @@ export default function VaccineDataGrid(
       );
     }
 
-    const hospitalsByCity = hospitals.reduce((byCity: {[Location]: Hospital[]}, hospital) => {
+    const hospitalsByCity = hospitals.reduce((byCity: { [Location]: Hospital[] }, hospital) => {
       if (hospital.location in byCity) {
         byCity[hospital.location].push(hospital);
         return byCity;
@@ -47,57 +49,41 @@ export default function VaccineDataGrid(
 
     const makeAccordionID: (Availability) => string = (a) => `accordian-${a.split(' ').join('_')}`;
 
-    const makeCardGridForCity: ([string, Hospital[]], Availability) =>
-      React.Node = ([location, locationHospitals], locationAvailability) => {
+    const makeCardGridForCity: ([Location, Hospital[]], Availability) =>
+      React.Element<typeof AccordionItem> = ([location, lHospitals], locationAvailability) => {
         const makeCollapseID: (string) => string = (l) => `accordian-collapse-${l}-${locationAvailability
           .split(' ')
           .join('_')}`;
         return (
-          <div className="accordion-item">
-            <h2 className="accordion-header" id="headingOne">
-              <button
-                className="accordion-button collapsed"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target={`#${makeCollapseID(location)}`}
-                aria-expanded="true"
-                aria-controls="collapseOne"
-              >
-                {location}
-              </button>
-            </h2>
-            <div
-              id={makeCollapseID(location)}
-              className="accordion-collapse collapse"
-              aria-labelledby="headingOne"
-              data-bs-parent={`#${makeAccordionID(availability)}`}
-            >
-              <div className="accordion-body">
-                <div className="row row-cols-1 row-cols-md-4 g-3">
-                  {locationHospitals.map((hospital) => (
-                    <div className="col" key={hospital.hospitalId.toString()}>
-                      <Card
-                        address={hospital.address}
-                        availability={getAvailability(hospital)}
-                        buttonText={buttonText}
-                        department={hospital.department}
-                        hospitalId={hospital.hospitalId}
-                        location={hospital.location}
-                        name={hospital.name}
-                        phone={hospital.phone}
-                        website={hospital.website}
-                      />
-                    </div>
-                  ))}
+          <AccordionItem
+            id={makeCollapseID(location)}
+            title={location}
+            parentID={makeAccordionID(availability)}
+          >
+            <div className="row row-cols-1 row-cols-md-4 g-3">
+              {lHospitals.map((hospital) => (
+                <div className="col" key={hospital.hospitalId.toString()}>
+                  <Card
+                    address={hospital.address}
+                    availability={getAvailability(hospital)}
+                    buttonText={buttonText}
+                    department={hospital.department}
+                    hospitalId={hospital.hospitalId}
+                    location={hospital.location}
+                    name={hospital.name}
+                    phone={hospital.phone}
+                    website={hospital.website}
+                  />
                 </div>
-              </div>
+              ))}
             </div>
-          </div>
+          </AccordionItem>
+
         );
       };
 
     return (
-      <div className="accordion" id={makeAccordionID(availability)}>
+      <Accordion id={makeAccordionID(availability)}>
         {
         Object
           .entries(hospitalsByCity)
@@ -105,7 +91,7 @@ export default function VaccineDataGrid(
           .map((hospitalsByLocation) => makeCardGridForCity(hospitalsByLocation, availability))
 
       }
-      </div>
+      </Accordion>
     );
   };
   return (

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -48,12 +48,11 @@ export default function VaccineDataGrid(
     }, {});
 
     const makeAccordionID: (Availability) => string = (a) => `accordian-${a.split(' ').join('_')}`;
-
+    const makeCollapseID: (string) => string = (l) => `accordian-collapse-${l}-${availability
+      .split(' ')
+      .join('_')}`;
     const makeCardGridForCity: ([Location, Hospital[]], Availability) =>
-      React.Element<typeof AccordionItem> = ([location, lHospitals], locationAvailability) => {
-        const makeCollapseID: (string) => string = (l) => `accordian-collapse-${l}-${locationAvailability
-          .split(' ')
-          .join('_')}`;
+      React.Element<typeof AccordionItem> = ([location, lHospitals]) => {
         return (
           <AccordionItem
             id={makeCollapseID(location)}

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -61,7 +61,7 @@ export default function VaccineDataGrid(
         <Accordion id={makeAccordionID(availability)}>
           {Object
             .entries(hospitalsByCity)
-            .map(([location: Location, locHospitals: Hospital[]], index: number) => (
+            .map(([location: Location, locHospitals: Hospital[]]) => (
               <AccordionItem
                 id={makeCollapseID(location)}
                 title={location}

--- a/frontend/Components/VaccineDataGrid.jsx
+++ b/frontend/Components/VaccineDataGrid.jsx
@@ -84,13 +84,10 @@ export default function VaccineDataGrid(
 
     return (
       <Accordion id={makeAccordionID(availability)}>
-        {
-        Object
+        {Object
           .entries(hospitalsByCity)
           // $FlowFixMe[incompatible-call]: Object.entries is unsound and returns mixed.
-          .map((hospitalsByLocation) => makeCardGridForCity(hospitalsByLocation, availability))
-
-      }
+          .map((hospitalsByLocation) => makeCardGridForCity(hospitalsByLocation, availability))}
       </Accordion>
     );
   };

--- a/frontend/Components/VaccineDataGrid/Accordion.jsx
+++ b/frontend/Components/VaccineDataGrid/Accordion.jsx
@@ -6,9 +6,22 @@ export default function Accordion(
   props: { id: string, children: React.Element<typeof AccordionItem>[] },
 ): React.Node {
   const { children, id } = props;
+  const [ expandedIndex, setExpandedIndex ] = React.useState(0);
+  console.log("Rendering with expanded index: ", expandedIndex);
+  const handleClick: (i: number) => void = i => {
+    console.log("Handling click of ", i);
+    i === expandedIndex ? setExpandedIndex(-1) : setExpandedIndex(i);
+  }
   return (
     <div className="accordion" id={id}>
-      {children}
+      {children.map((item, index) => React.cloneElement(
+        item,
+        {
+          collapsedByDefault: expandedIndex !== index,
+          parentID: id,
+          setExpandedIndex: () => handleClick(index),
+        },
+      ))}
     </div>
   );
 }

--- a/frontend/Components/VaccineDataGrid/Accordion.jsx
+++ b/frontend/Components/VaccineDataGrid/Accordion.jsx
@@ -1,0 +1,14 @@
+// @flow
+import * as React from 'react';
+import AccordionItem from './AccordionItem';
+
+export default function Accordion(
+  props: { id: string, children: React.Element<typeof AccordionItem>[] },
+): React.Node {
+  const { children, id } = props;
+  return (
+    <div className="accordion" id={id}>
+      {children}
+    </div>
+  );
+}

--- a/frontend/Components/VaccineDataGrid/Accordion.jsx
+++ b/frontend/Components/VaccineDataGrid/Accordion.jsx
@@ -6,12 +6,10 @@ export default function Accordion(
   props: { id: string, children: React.Element<typeof AccordionItem>[] },
 ): React.Node {
   const { children, id } = props;
-  const [ expandedIndex, setExpandedIndex ] = React.useState(0);
-  console.log("Rendering with expanded index: ", expandedIndex);
-  const handleClick: (i: number) => void = i => {
-    console.log("Handling click of ", i);
-    i === expandedIndex ? setExpandedIndex(-1) : setExpandedIndex(i);
-  }
+  const [expandedIndex, setExpandedIndex] = React.useState(0);
+  const handleClick: (i: number) => void = (i) => (i === expandedIndex
+    ? setExpandedIndex(-1)
+    : setExpandedIndex(i));
   return (
     <div className="accordion" id={id}>
       {children.map((item, index) => React.cloneElement(

--- a/frontend/Components/VaccineDataGrid/AccordionItem.jsx
+++ b/frontend/Components/VaccineDataGrid/AccordionItem.jsx
@@ -2,10 +2,21 @@
 import * as React from 'react';
 
 export default function AccordionItem(
-  props: { id: string, title: string, parentID?: string, children: React.Node, collapsedByDefault?: boolean, setExpandedIndex?: number => void},
+  props: {
+    id: string,
+    title: string,
+    parentID?: string,
+    children: React.Node,
+    collapsedByDefault?: boolean,
+    setExpandedIndex?: number => void},
 ): React.Node {
   const {
-    id, title, parentID, children, collapsedByDefault, setExpandedIndex
+    id,
+    title,
+    parentID,
+    children,
+    collapsedByDefault,
+    setExpandedIndex,
   } = props;
   const accordianButtonClassnames = collapsedByDefault ? 'accordion-button collapsed' : 'accordion-button';
   const accordionCollapseClassnames = collapsedByDefault ? 'accordion-collapse collapse' : 'accordion-collapse';
@@ -41,5 +52,5 @@ export default function AccordionItem(
 AccordionItem.defaultProps = {
   collapsedByDefault: true,
   parentID: '',
-  setExpandedIndex: (_: number) => {},
+  setExpandedIndex: () => {},
 };

--- a/frontend/Components/VaccineDataGrid/AccordionItem.jsx
+++ b/frontend/Components/VaccineDataGrid/AccordionItem.jsx
@@ -1,0 +1,32 @@
+// @flow
+import * as React from 'react';
+
+export default function AccordionItem(
+  props: {id: string, title: string, parentID: string},
+): React.Node {
+  const { id, title, parentID } = props;
+  return (
+    <div className="accordion-item">
+      <h2 className="accordion-header" id="headingOne">
+        <button
+          className="accordion-button collapsed"
+          type="button"
+          data-bs-toggle="collapse"
+          data-bs-target={`#${id}`}
+          aria-expanded="true"
+          aria-controls="collapseOne"
+        >
+          {title}
+        </button>
+      </h2>
+      <div
+        id={id}
+        className="accordion-collapse collapse"
+        aria-labelledby="headingOne"
+        data-bs-parent={parentID}
+      >
+        <div className="accordion-body" />
+      </div>
+    </div>
+  );
+}

--- a/frontend/Components/VaccineDataGrid/AccordionItem.jsx
+++ b/frontend/Components/VaccineDataGrid/AccordionItem.jsx
@@ -2,31 +2,44 @@
 import * as React from 'react';
 
 export default function AccordionItem(
-  props: {id: string, title: string, parentID: string},
+  props: { id: string, title: string, parentID?: string, children: React.Node, collapsedByDefault?: boolean, setExpandedIndex?: number => void},
 ): React.Node {
-  const { id, title, parentID } = props;
+  const {
+    id, title, parentID, children, collapsedByDefault, setExpandedIndex
+  } = props;
+  const accordianButtonClassnames = collapsedByDefault ? 'accordion-button collapsed' : 'accordion-button';
+  const accordionCollapseClassnames = collapsedByDefault ? 'accordion-collapse collapse' : 'accordion-collapse';
   return (
     <div className="accordion-item">
       <h2 className="accordion-header" id="headingOne">
         <button
-          className="accordion-button collapsed"
+          className={accordianButtonClassnames}
           type="button"
           data-bs-toggle="collapse"
           data-bs-target={`#${id}`}
           aria-expanded="true"
           aria-controls="collapseOne"
+          onClick={setExpandedIndex}
         >
           {title}
         </button>
       </h2>
       <div
         id={id}
-        className="accordion-collapse collapse"
+        className={accordionCollapseClassnames}
         aria-labelledby="headingOne"
-        data-bs-parent={parentID}
+        data-bs-parent={`#${parentID ?? ''}`}
       >
-        <div className="accordion-body" />
+        <div className="accordion-body">
+          {children}
+        </div>
       </div>
     </div>
   );
 }
+
+AccordionItem.defaultProps = {
+  collapsedByDefault: true,
+  parentID: '',
+  setExpandedIndex: (_: number) => {},
+};

--- a/frontend/Components/VaccineDataGrid/Card.jsx
+++ b/frontend/Components/VaccineDataGrid/Card.jsx
@@ -1,8 +1,8 @@
 // @flow
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import type { Availability } from '../Types/Availability';
-import type { Location } from '../Types/Location';
+import type { Availability } from '../../Types/Availability';
+import type { Location } from '../../Types/Location';
 
 function getBadgeClassname(availability: Availability): string {
   switch (availability) {

--- a/frontend/Components/VaccineDataGrid/Cards.jsx
+++ b/frontend/Components/VaccineDataGrid/Cards.jsx
@@ -1,0 +1,29 @@
+// @flow
+import * as React from 'react';
+import Card from './Card';
+import { getAvailability } from '../../Types/Hospital';
+
+import type { Hospital } from '../../Types/Hospital';
+import type { VaccineType } from '../../Types/VaccineType';
+
+export default function Cards(
+  props: { hospitals: Hospital[], vaccineType: VaccineType, buttonText: string},
+): React.Node {
+  const { hospitals, buttonText, vaccineType } = props;
+
+  return hospitals.map((hospital) => (
+    <div className="col" key={hospital.hospitalId.toString()}>
+      <Card
+        address={hospital.address}
+        availability={getAvailability(hospital, vaccineType)}
+        buttonText={buttonText}
+        department={hospital.department}
+        hospitalId={hospital.hospitalId}
+        location={hospital.location}
+        name={hospital.name}
+        phone={hospital.phone}
+        website={hospital.website}
+      />
+    </div>
+  ));
+}

--- a/frontend/Types/Hospital.js
+++ b/frontend/Types/Hospital.js
@@ -1,6 +1,7 @@
 // @flow
 import type { Availability } from './Availability';
 import type { Location } from './Location';
+import type { VaccineType } from './VaccineType';
 
 export type Hospital = {|
     address: string,
@@ -13,3 +14,8 @@ export type Hospital = {|
     selfPaidAvailability: Availability,
     website: string,
   |};
+
+export function getAvailability(hospital: Hospital, vaccineType: VaccineType): Availability {
+  return vaccineType === 'SelfPaid'
+    ? hospital.selfPaidAvailability : hospital.governmentPaidAvailability;
+}

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -25,7 +25,6 @@
 <body>
     <div id="root"></div>
     <script type="module" src="./index.jsx"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-gtEjrD/SeCtmISkJkNUaaKMoLD0//ElJ19smozuHV6z3Iehds+3Ulb9Bn9Plx0x4" crossorigin="anonymous"></script>
 </body>
 
 </html>


### PR DESCRIPTION
This took a surprising amount of time for me.

We currently have ~390 hospitals. That's too much data to show to the user at once. 

## This PR:
1. Removes the Bootstrap JS dependency. We're only using it to toggle the navbar so I added in some JS to do that. We can make it prettier later. 
2. Sorts hospitals by location. 
3. When there are more hospitals than 20 for each availability category, we collapse into accordions by city. 
## Test Plan: 
[X] Yarn lint; yarn tc completes without error. 
[X] Load test server on device. Confirm that it works as expected. 
![Screenshot from 2021-05-22 23-07-19](https://user-images.githubusercontent.com/8745371/119231261-8a7b9780-bb52-11eb-8522-cb5ee2cab2f8.png)
![Screenshot from 2021-05-22 23-07-46](https://user-images.githubusercontent.com/8745371/119231262-8c455b00-bb52-11eb-8349-464080324b40.png)

