### PR TITLE
Host frontend assets on GitHub Pages.

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 # NOTE: this file is shared between Flask (backend) and Parcel (frontend)
-# You can
+# You can add local overrides in `.env.development.local` file.
 
 # Frontend
 API_URL=http://localhost:5000

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,11 @@
+# NOTE: this file is shared between Flask (backend) and Parcel (frontend)
+# You can
+
+# Frontend
+API_URL=http://localhost:5000
+
+# Backend
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_USERNAME=""
+REDIS_PASSWORD=""

--- a/.env.development
+++ b/.env.development
@@ -3,9 +3,3 @@
 
 # Frontend
 API_URL=http://localhost:5000
-
-# Backend
-REDIS_HOST=localhost
-REDIS_PORT=6379
-REDIS_USERNAME=""
-REDIS_PASSWORD=""

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,6 +40,8 @@ jobs:
 
       - name: Build Site
         working-directory: ./main
+        env:
+          API_URL: https://vaxx.tw
         run: yarn run build
 
       - name: Commit into gh-pages branch

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+# Builds static site and push to GitHub Pages
+name: Build
+
+on:
+  push:
+    branches:
+      - "master"
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          path: main
+
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+          path: gh-pages
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Dependencies
+        working-directory: ./main
+        run: yarn
+
+      - name: Build Site
+        working-directory: ./main
+        run: yarn run build
+
+      - name: Commit into gh-pages branch
+        working-directory: ./gh-pages
+        run: |
+          git config --local user.name "Builder by ${{ github.actor	 }}"
+          git config --local user.email "noreply@g0v.tw"
+
+          cp -R ../main/dist/* .
+          git add .
+          git commit -m "Rebuild at $(date)"
+          git push

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -50,6 +50,9 @@ jobs:
           git config --local user.name "Builder by ${{ github.actor	 }}"
           git config --local user.email "noreply@g0v.tw"
 
+          # cleanup old files
+          git ls-files . | xargs git rm
+
           cp -R ../main/dist/* .
           git add .
           git commit -m "Rebuild at $(date)"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ python-dotenv = "*"
 types-redis = "*"
 aiohttp = "*"
 flask = {extras = ["async"], version = "*"}
+flask-cors = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "a889949bf50ffc52159b53f61ddfd34bc04c85900eaac1dcda8911b16a7cc063"
+            "sha256": "c6d3418b54fa3223d3628ef4ef3b7b09520ddf9b87a568f2cba814c38808d9ea"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -109,22 +109,30 @@
         },
         "click": {
             "hashes": [
-                "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136",
-                "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.0"
+            "version": "==8.0.1"
         },
         "flask": {
             "extras": [
                 "async"
             ],
             "hashes": [
-                "sha256:168e8507792cb8a3aa06afbe5d4d431d3e07c6318bc3893ceecb81aff09f848d",
-                "sha256:1833a4b36ace08dfa1510d86f1bb6fc595d990ec1b838e03ac8dd80ac0705954"
+                "sha256:1c4c257b1892aec1398784c63791cbaa43062f1f7aeb555c4da961b20ee68f55",
+                "sha256:a6209ca15eb63fc9385f38e452704113d679511d9574d09b2cf9183ae7d20dc9"
             ],
             "index": "pypi",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
+        },
+        "flask-cors": {
+            "hashes": [
+                "sha256:74efc975af1194fc7891ff5cd85b0f7478be4f7f59fe158102e91abb72bb4438",
+                "sha256:b60839393f3b84a0f3746f6cdca56c1ad7426aa738b70d6c61375857823181de"
+            ],
+            "index": "pypi",
+            "version": "==3.0.10"
         },
         "idna": {
             "hashes": [
@@ -136,59 +144,59 @@
         },
         "itsdangerous": {
             "hashes": [
-                "sha256:99b1053ccce68066dfc0b4465ef8779027e6d577377c8270e21a3d6289cac111",
-                "sha256:e2cb4ae918f07ab2a2f9a91dec2695bd1f25a19d31861a70015ad537ccb5e807"
+                "sha256:5174094b9637652bdb841a3029700391451bd092ba3db90600dea710ba28e97c",
+                "sha256:9e724d68fc22902a1435351f84c3fb8623f303fffcc566a4cb952df8c572cff0"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "jinja2": {
             "hashes": [
-                "sha256:2f2de5285cf37f33d33ecd4a9080b75c87cd0c1994d5a9c6df17131ea1f049c6",
-                "sha256:ea8d7dd814ce9df6de6a761ec7f1cac98afe305b8cdc4aaae4e114b8d8ce24c5"
+                "sha256:1f06f2da51e7b56b8f238affdd6b4e2c61e39598a378cc49345bc1bd42a978a4",
+                "sha256:703f484b47a6af502e743c9122595cc812b0271f661722403114f71a79d0f5a4"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==3.0.0"
+            "version": "==3.0.1"
         },
         "markupsafe": {
             "hashes": [
-                "sha256:007dc055dbce5b1104876acee177dbfd18757e19d562cd440182e1f492e96b95",
-                "sha256:031bf79a27d1c42f69c276d6221172417b47cb4b31cdc73d362a9bf5a1889b9f",
-                "sha256:161d575fa49395860b75da5135162481768b11208490d5a2143ae6785123e77d",
-                "sha256:24bbc3507fb6dfff663af7900a631f2aca90d5a445f272db5fc84999fa5718bc",
-                "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0",
-                "sha256:32200f562daaab472921a11cbb63780f1654552ae49518196fc361ed8e12e901",
-                "sha256:3261fae28155e5c8634dd7710635fe540a05b58f160cef7713c7700cb9980e66",
-                "sha256:3b54a9c68995ef4164567e2cd1a5e16db5dac30b2a50c39c82db8d4afaf14f63",
-                "sha256:3c352ff634e289061711608f5e474ec38dbaa21e3e168820d53d5f4015e5b91b",
-                "sha256:3fb47f97f1d338b943126e90b79cad50d4fcfa0b80637b5a9f468941dbbd9ce5",
-                "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c",
-                "sha256:45535241baa0fc0ba2a43961a1ac7562ca3257f46c4c3e9c0de38b722be41bd1",
-                "sha256:4aca81a687975b35e3e80bcf9aa93fe10cd57fac37bf18b2314c186095f57e05",
-                "sha256:4cc563836f13c57f1473bc02d1e01fc37bab70ad4ee6be297d58c1d66bc819bf",
-                "sha256:4fae0677f712ee090721d8b17f412f1cbceefbf0dc180fe91bab3232f38b4527",
-                "sha256:58bc9fce3e1557d463ef5cee05391a05745fd95ed660f23c1742c711712c0abb",
-                "sha256:664832fb88b8162268928df233f4b12a144a0c78b01d38b81bdcf0fc96668ecb",
-                "sha256:70820a1c96311e02449591cbdf5cd1c6a34d5194d5b55094ab725364375c9eb2",
-                "sha256:79b2ae94fa991be023832e6bcc00f41dbc8e5fe9d997a02db965831402551730",
-                "sha256:83cf0228b2f694dcdba1374d5312f2277269d798e65f40344964f642935feac1",
-                "sha256:87de598edfa2230ff274c4de7fcf24c73ffd96208c8e1912d5d0fee459767d75",
-                "sha256:8f806bfd0f218477d7c46a11d3e52dc7f5fdfaa981b18202b7dc84bbc287463b",
-                "sha256:90053234a6479738fd40d155268af631c7fca33365f964f2208867da1349294b",
-                "sha256:a00dce2d96587651ef4fa192c17e039e8cfab63087c67e7d263a5533c7dad715",
-                "sha256:a08cd07d3c3c17cd33d9e66ea9dee8f8fc1c48e2d11bd88fd2dc515a602c709b",
-                "sha256:a19d39b02a24d3082856a5b06490b714a9d4179321225bbf22809ff1e1887cc8",
-                "sha256:d00a669e4a5bec3ee6dbeeeedd82a405ced19f8aeefb109a012ea88a45afff96",
-                "sha256:dab0c685f21f4a6c95bfc2afd1e7eae0033b403dd3d8c1b6d13a652ada75b348",
-                "sha256:df561f65049ed3556e5b52541669310e88713fdae2934845ec3606f283337958",
-                "sha256:e4570d16f88c7f3032ed909dc9e905a17da14a1c4cfd92608e3fda4cb1208bbd",
-                "sha256:e77e4b983e2441aff0c0d07ee711110c106b625f440292dfe02a2f60c8218bd6",
-                "sha256:e79212d09fc0e224d20b43ad44bb0a0a3416d1e04cf6b45fed265114a5d43d20",
-                "sha256:f58b5ba13a5689ca8317b98439fccfbcc673acaaf8241c1869ceea40f5d585bf",
-                "sha256:fef86115fdad7ae774720d7103aa776144cf9b66673b4afa9bcaa7af990ed07b"
+                "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298",
+                "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64",
+                "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b",
+                "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567",
+                "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff",
+                "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74",
+                "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35",
+                "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26",
+                "sha256:3c112550557578c26af18a1ccc9e090bfe03832ae994343cfdacd287db6a6ae7",
+                "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75",
+                "sha256:49e3ceeabbfb9d66c3aef5af3a60cc43b85c33df25ce03d0031a608b0a8b2e3f",
+                "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135",
+                "sha256:53edb4da6925ad13c07b6d26c2a852bd81e364f95301c66e930ab2aef5b5ddd8",
+                "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a",
+                "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914",
+                "sha256:6557b31b5e2c9ddf0de32a691f2312a32f77cd7681d8af66c2692efdbef84c18",
+                "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8",
+                "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2",
+                "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d",
+                "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b",
+                "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f",
+                "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb",
+                "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833",
+                "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415",
+                "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902",
+                "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9",
+                "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d",
+                "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066",
+                "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f",
+                "sha256:f5653a225f31e113b152e56f154ccbe59eeb1c7487b39b9d9f9cdb58e6c79dc5",
+                "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94",
+                "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509",
+                "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51",
+                "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "multidict": {
             "hashes": [
@@ -257,6 +265,14 @@
             "index": "pypi",
             "version": "==2.25.1"
         },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "soupsieve": {
             "hashes": [
                 "sha256:052774848f448cf19c7e959adf5566904d525f33a3f8b6ba6f6f8f26ec7de0cc",
@@ -267,10 +283,10 @@
         },
         "types-redis": {
             "hashes": [
-                "sha256:501a0767d5d305c8b3dd508d13d02b036dc9c94fc837a4556721fc19ae3cd379"
+                "sha256:b8df5f3ff7f4ad0d6a2bd090c37b5f2ff657d7d2b38b0e91621f4f9ae221cbfc"
             ],
             "index": "pypi",
-            "version": "==0.1.15"
+            "version": "==0.1.16"
         },
         "typing-extensions": {
             "hashes": [
@@ -290,11 +306,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:3389bbfe6d40c6dd25e6d3f974155163c8b3de5bbda6a89342d4ab93fae80ba0",
-                "sha256:64c02f6495ba01eddd6625b3675f357cd358a73f1e38458a56ad86c5baa30b53"
+                "sha256:1de1db30d010ff1af14a009224ec49ab2329ad2cde454c8a708130642d579c42",
+                "sha256:6c1ec500dcdba0baa27600f6a22f6333d8b662d22027ff9f6202e3367413caa8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2.0.0"
+            "version": "==2.0.1"
         },
         "yarl": {
             "hashes": [
@@ -374,19 +390,19 @@
         },
         "cfgv": {
             "hashes": [
-                "sha256:32e43d604bbe7896fe7c248a9c2276447dbef840feb28fe20494f62af110211d",
-                "sha256:cf22deb93d4bcf92f345a5c3cd39d3d41d6340adc60c78bbbd6588c384fda6a1"
+                "sha256:9e600479b3b99e8af981ecdfc80a0296104ee610cab48a5ae4ffd0b668650eb1",
+                "sha256:b449c9c6118fe8cca7fa5e00b9ec60ba08145d281d52164230a69211c5d597a1"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==3.2.0"
+            "version": "==3.3.0"
         },
         "click": {
             "hashes": [
-                "sha256:7d8c289ee437bcb0316820ccee14aefcb056e58d31830ecab8e47eda6540e136",
-                "sha256:e90e62ced43dc8105fb9a26d62f0d9340b5c8db053a814e25d95c19873ae87db"
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==8.0.0"
+            "version": "==8.0.1"
         },
         "dataclasses-json": {
             "hashes": [
@@ -420,11 +436,11 @@
         },
         "identify": {
             "hashes": [
-                "sha256:9bcc312d4e2fa96c7abebcdfb1119563b511b5e3985ac52f60d9116277865b2e",
-                "sha256:ad9f3fa0c2316618dc4d840f627d474ab6de106392a4f00221820200f490f5a8"
+                "sha256:01ebbc7af37043806216c7550539210cde4f82451983eb8735a02b3b9d013e40",
+                "sha256:1560bb645b93d5c05c3535c72a4f4884133006423d02c692ac6862a45eb0d521"
             ],
             "markers": "python_full_version >= '3.6.1'",
-            "version": "==2.2.4"
+            "version": "==2.2.6"
         },
         "isort": {
             "hashes": [
@@ -515,11 +531,11 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:70c5ec1f30406250b706eda35e868b87e3e4ba099af8787e3e8b4b01e84f4712",
-                "sha256:900d3c7e1bf4cf0374bb2893c24c23304952181405b4d88c9c40b72bda1bb8a9"
+                "sha256:764972c60693dc668ba8e86eb29654ec3144501310f7198742a767bec385a378",
+                "sha256:b679d0fddd5b9d6d98783ae5f10fd0c4c59954f375b70a58cbe1ce9bcf9809a4"
             ],
             "index": "pypi",
-            "version": "==2.12.1"
+            "version": "==2.13.0"
         },
         "psutil": {
             "hashes": [
@@ -565,12 +581,12 @@
         },
         "pyre-check": {
             "hashes": [
-                "sha256:34402a3ea4d3c597b113824a9ba4c62a21830b4f0be51ba25b92f61690be7328",
-                "sha256:6796015cc716326d0479e14cfd71c0125b6a1a0fc44e72992d93f7aa0725c195",
-                "sha256:bdf024ebd4a4cfe66429ef7a9500ae9f9c00408ae5c4268196d616a54b450e53"
+                "sha256:989a82f1f76dd572da46e33bde34e56e7949f272df32f96d1f397241f42ebb13",
+                "sha256:d5c03de101610d534eaf3d7b654702d91b95505209886feed211a30ded789daa",
+                "sha256:ed000307bcc7999b6e651bd8fa3d7716d6b3cc272855bf677643438f77ff54c1"
             ],
             "index": "pypi",
-            "version": "==0.9.2"
+            "version": "==0.9.3"
         },
         "pyre-extensions": {
             "hashes": [
@@ -713,11 +729,11 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:307a555cf21e1550885c82120eccaf5acedf42978fd362d32ba8410f9593f543",
-                "sha256:72cf267afc04bf9c86ec932329b7e94db6a0331ae9847576daaa7ca3c86b29a4"
+                "sha256:14fdf849f80dbb29a4eb6caa9875d476ee2a5cf76a5f5415fa2f1606010ab467",
+                "sha256:2b0126166ea7c9c3661f5b8e06773d28f83322de7a3ff7d06f0aed18c9de6a76"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==20.4.6"
+            "version": "==20.4.7"
         },
         "wrapt": {
             "hashes": [

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,4 +1,6 @@
 from flask import Flask, render_template, json, wrappers
+from flask_cors import CORS
+
 import argparse
 import redis, csv, sys, os
 from typing import TypedDict, Tuple, Dict, Callable, List, Any, Optional
@@ -41,6 +43,10 @@ app = Flask(
     template_folder="../dist",
 )
 
+# XXX: Allowing CORS for all endpoints from any origins may introduce problems
+# in the future. Consider limiting endpoints to API resouces only.
+# Currently limited to semanticly read-only verbs.
+CORS(app, resources={r"/*": {"origins": "*", "methods": ["GET", "HEAD", "OPTIONS"]}})
 
 def get_availability_from_server() -> Dict[HospitalID, HospitalAvailabilitySchema]:
 

--- a/backend/app.py
+++ b/backend/app.py
@@ -59,6 +59,7 @@ app = Flask(
 # Currently limited to semanticly read-only verbs.
 CORS(app, resources={r"/*": {"origins": "*", "methods": ["GET", "HEAD", "OPTIONS"]}})
 
+
 def get_availability_from_server() -> Dict[HospitalID, HospitalAvailabilitySchema]:
 
     scraper_hospital_ids = list(map(lambda x: x.hospital_id, local_scraper.PARSERS))

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -8,9 +8,10 @@ export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
   const [vaccineType, setVaccineType] = React.useState('GovernmentPaid');
   const [gt] = useTranslation('app');
+  const apiURL = process.env.API_URL || '';
   React.useEffect(() => {
     const url = vaccineType === 'SelfPaid' ? '/self_paid_hospitals' : '/government_paid_hospitals';
-    fetch(process.env.API_URL + url).then((data) => data.json()).then((res) => setRows(res));
+    fetch(apiURL + url).then((data) => data.json()).then((res) => setRows(res));
   }, [vaccineType]); // Empty list makes this useEffect similar to componentDidMount();
 
   return (

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -9,8 +9,8 @@ export default function Home(): React.Node {
   const [vaccineType, setVaccineType] = React.useState('GovernmentPaid');
   const [gt] = useTranslation('app');
   React.useEffect(() => {
-    const url = vaccineType === 'SelfPaid' ? './self_paid_hospitals' : './government_paid_hospitals';
-    fetch(url).then((data) => data.json()).then((res) => setRows(res));
+    const url = vaccineType === 'SelfPaid' ? '/self_paid_hospitals' : '/government_paid_hospitals';
+    fetch(process.env.API_URL + url).then((data) => data.json()).then((res) => setRows(res));
   }, [vaccineType]); // Empty list makes this useEffect similar to componentDidMount();
 
   return (

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "backend": "parcel build ./frontend/index.html; cd backend; pipenv run python app.py --scrape",
-    "build": "parcel build ./frontend/index.html",
+    "build": "parcel build ./frontend/index.html --public-url ./",
     "fixpipenv": "pipenv lock --pre --clear",
     "frontend": "parcel serve ./frontend/index.html",
     "lint": "pipenv run black backend/*; yarn eslint frontend --ext .js,.jsx --fix",


### PR DESCRIPTION
This patch introduces a build pipeline that hosts frontend assets on GitHub Pages.

In order to do that, I've done these:

1. Changed Parcel build URL so that it points to relative URL, instead of root URL. (Important if we don't have a custom domain)
    * we may use `vaxx.tw` custom domain and move API to `api.vaxx.tw` for the next step, but that requires further migration, so let's run it on `g0v.tw/vaccinate` first.
2. Added CORS rules to backend.
    * Currently allowing *ANY* origin `*` to access `GET`, `HEAD` and `OPTIONS`.

What I didn't change by intention:

* Backend server still responds to `GET /` => `index.html`. Keeping this for now so that we can do iterative migration.

To @kevinjcliao :

It seems that `gh-pages` branch already exists. If you merge this branch, all files in that branch will be replaced by Parcel build. If there is any file that is being accessed somewhere else, please let me know, I'll come up with a solution.

Closes #67 

<img width="1063" alt="Screen Shot 2021-05-25 at 20 10 47" src="https://user-images.githubusercontent.com/10737/119495787-5b089d00-bd95-11eb-8240-49f06236b844.png">
