### PR TITLE
Remove code distinguishing between government-paid and self-paid

### DIFF
--- a/frontend/Components/VaccineInfo.jsx
+++ b/frontend/Components/VaccineInfo.jsx
@@ -19,23 +19,6 @@ export default function VaccineInfo(
 
   return (
     <div>
-      {
-      vaccineType === 'SelfPaid' ? (
-        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 20 }}>
-          <div className="alert alert-warning" role="alert" style={{ textAlign: 'center', maxWidth: 800 }}>
-            <p>
-              <b>
-                {t('dataGrid:selfPaidVaccineClosure:txt-notice')}
-              </b>
-            </p>
-            <p>
-              {t('dataGrid:selfPaidVaccineClosure:txt-selfPaid2ndShot')}
-            </p>
-          </div>
-        </div>
-      )
-        : null
-    }
       <div style={{ marginTop: 20 }}>
         <h3>{t('txt-hospitalsWithAppointmentsTitle')}</h3>
         <p>

--- a/frontend/Components/VaccineInfo/DataGrid.jsx
+++ b/frontend/Components/VaccineInfo/DataGrid.jsx
@@ -18,13 +18,6 @@ export default function DataGrid(props: {
   const {
     hospitals, buttonText, vaccineType,
   } = props;
-  if (hospitals.length === 0) {
-    return (
-      <div style={{ textAlign: 'center' }}>
-        <p className="lead"><i>{t('txt-noHospitals')}</i></p>
-      </div>
-    );
-  }
 
   const hospitalsByCity = hospitals.reduce((byCity: { [Location]: Hospital[] }, hospital) => {
     if (hospital.location in byCity) {
@@ -38,7 +31,15 @@ export default function DataGrid(props: {
   }, {});
 
   const locations: string[] = Object.keys(hospitalsByCity);
-  const [selectedLocation, setLocation] = React.useState(locations[0]);
+  const [selectedLocation, setLocation] = React.useState('臺北市');
+
+  if (hospitals.length === 0) {
+    return (
+      <div style={{ textAlign: 'center' }}>
+        <p className="lead"><i>{t('txt-noHospitals')}</i></p>
+      </div>
+    );
+  }
 
   const makeCardGrid: (Hospital[]) =>
   React.Node = (localHospitals) => (

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -1,69 +1,21 @@
 // @flow
 import * as React from 'react';
-import { useTranslation } from 'react-i18next';
 import VaccineInfo from '../Components/VaccineInfo';
-import Spinner from '../Components/Spinner';
 
 export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
-  const [vaccineType, setVaccineType] = React.useState('GovernmentPaid');
-  const [gt] = useTranslation('app');
   const apiURL = process.env.API_URL || '';
   React.useEffect(() => {
-    const url = vaccineType === 'SelfPaid' ? '/self_paid_hospitals' : '/government_paid_hospitals';
+    const url = '/government_paid_hospitals';
     fetch(apiURL + url).then((data) => data.json()).then((res) => setRows(res));
-  }, [vaccineType]); // Empty list makes this useEffect similar to componentDidMount();
+  }, []); // Empty list makes this useEffect similar to componentDidMount();
 
   return (
     <>
-      {rows.length === 0 ? <Spinner />
-        : (
-          <>
-            <div style={{ textAlign: 'center' }}>
-              <form
-                className="btn-group"
-                role="group"
-                aria-label="Select type of vaccination."
-              >
-                {/* eslint-disable jsx-a11y/label-has-associated-control */}
-                <input
-                  type="radio"
-                  className="btn-check"
-                  name="btnradio"
-                  id="btnradio1"
-                  autoComplete="off"
-                  onClick={() => { setRows([]); setVaccineType('SelfPaid'); }}
-                  checked={vaccineType === 'SelfPaid'}
-                />
-                <label
-                  className="btn btn-outline-primary"
-                  htmlFor="btnradio1"
-                >
-                  { gt('txt-selfPaidVaccine') }
-                </label>
-                <input
-                  type="radio"
-                  className="btn-check"
-                  name="btnradio"
-                  id="btnradio2"
-                  autoComplete="off"
-                  onClick={() => { setRows([]); setVaccineType('GovernmentPaid'); }}
-                  checked={vaccineType === 'GovernmentPaid'}
-                />
-                <label
-                  className="btn btn-outline-primary"
-                  htmlFor="btnradio2"
-                >
-                  { gt('txt-governmentPaidVaccine') }
-                </label>
-              </form>
-            </div>
-            <VaccineInfo
-              vaccineType={vaccineType}
-              rows={rows}
-            />
-          </>
-        )}
+      <VaccineInfo
+        vaccineType="GovernmentPaid"
+        rows={rows}
+      />
     </>
   );
 }


### PR DESCRIPTION
# Context
Self-paid vaccination program is over. 

# This PR
Removes the selector for government-paid vs. self-paid vaccinations. 

- [X] Yarn test, yarn lint passes. 
- [X] website renders successfully.