### PR TITLE
[3][Performance] Query airtable by city

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -92,9 +92,12 @@ async def get_popup_news(offset: str = "") -> PopupVaccineNews:
             return result
 
 
-async def get_hospitals_from_airtable(offset: str = "") -> List[Hospital]:
+async def get_hospitals_from_airtable(
+    offset: str = "", city: str = "臺北市"
+) -> List[Hospital]:
+    formula: str = f"{{施打站縣市（自動）}}='{city}'"
     url_params: AirTableRequestParams = {
-        "filterByFormula": None,
+        "filterByFormula": formula,
         "offset": offset,
         "maxRecords": 9999,
         "view": "給前端顯示用的資料",
@@ -167,7 +170,8 @@ async def government_paid_hospital_data() -> List[Hospital]:
 # pyre-fixme[56]: Decorator async types are not type-checked.
 @app.route("/government_paid_hospitals")
 async def government_paid_hospitals() -> wrappers.Response:
-    data = await government_paid_hospital_data()
+    print(request.args, file=sys.stdout)
+    data = await get_hospitals_from_airtable()
     response = app.response_class(
         response=json.dumps(data),
         status=200,

--- a/backend/app.py
+++ b/backend/app.py
@@ -142,7 +142,7 @@ def parse_airtable_json_for_hospital(raw_data: Dict[str, Any]) -> Hospital:
         "governmentPaidAvailability": AppointmentAvailability.NO_DATA,
         "hospitalId": "0",
         "location": raw_data["施打站縣市（自動）"],
-        "county": raw_data.get("施打站行政區（自動）", "無資料"),
+        "district": raw_data.get("施打站行政區（自動）", "無資料"),
         "name": raw_data["施打站全稱（自動）"],
         "phone": raw_data.get("預約電話（自動）", "無資料"),
         "website": raw_data.get("實際預約網址（手動）", raw_data.get("官方提供網址（自動）", None)),

--- a/backend/app.py
+++ b/backend/app.py
@@ -170,8 +170,8 @@ async def government_paid_hospital_data() -> List[Hospital]:
 # pyre-fixme[56]: Decorator async types are not type-checked.
 @app.route("/government_paid_hospitals")
 async def government_paid_hospitals() -> wrappers.Response:
-    print(request.args, file=sys.stdout)
-    data = await get_hospitals_from_airtable()
+    city: str = request.args.get("city")
+    data = await get_hospitals_from_airtable("", city)
     response = app.response_class(
         response=json.dumps(data),
         status=200,

--- a/backend/hospital_types.py
+++ b/backend/hospital_types.py
@@ -17,7 +17,7 @@ class Hospital(TypedDict):
     governmentPaidAvailability: AppointmentAvailability
     hospitalId: HospitalID
     location: str
-    county: str
+    district: str
     name: str
     phone: str
     selfPaidAvailability: AppointmentAvailability

--- a/backend/migrate.py
+++ b/backend/migrate.py
@@ -21,7 +21,7 @@ def main() -> None:
             "governmentPaidAvailability": AppointmentAvailability.NO_DATA,
             "hospitalId": row["編號"],
             "location": row["縣市"],
-            "county": "",
+            "district": "",
             "name": row["醫院名稱"],
             "phone": row["電話"],
             "website": row["Website"],

--- a/frontend/Components/VaccineInfo.jsx
+++ b/frontend/Components/VaccineInfo.jsx
@@ -14,9 +14,16 @@ export default function VaccineInfo(props: {
   vaccineType: VaccineType,
   selectedLocation: Location,
   setLocation: (Location) => void,
+  selectedDistrict: ?string,
+  setDistrict: (?string) => void,
 }): React.Node {
   const {
-    rows, vaccineType, selectedLocation, setLocation,
+    rows,
+    vaccineType,
+    selectedLocation,
+    setLocation,
+    selectedDistrict,
+    setDistrict,
   } = props;
   const { t } = useTranslation('dataGrid');
   const [tNav] = useTranslation('nav');
@@ -31,19 +38,17 @@ export default function VaccineInfo(props: {
     (row) => getAvailability(row, vaccineType) === 'No data',
   );
 
-  const [selectedCounty, setCounty] = React.useState('null');
-
   if (rows.length === 0) {
     return <div>獲取資料中...</div>;
   }
 
-  const counties = new Set(rows.map((hospital) => hospital.county));
+  const districts = new Set(rows.map((hospital) => hospital.district));
   function changeLocations(event) {
     setLocation(event.target.value);
-    setCounty('null');
+    setDistrict(null);
   }
-  function changeCounty(event) {
-    setCounty(event.target.value);
+  function changeDistrict(event) {
+    setDistrict(event.target.value);
   }
 
   return (
@@ -85,12 +90,12 @@ export default function VaccineInfo(props: {
                 <select
                   name="county"
                   className="form-select"
-                  onChange={changeCounty}
-                  value={selectedCounty}
+                  onChange={changeDistrict}
+                  value={selectedDistrict}
                 >
                   <option value="null">全部地區</option>
-                  {[...counties].map((county) => (
-                    <option value={county}>{county}</option>
+                  {[...districts].map((district) => (
+                    <option value={district}>{district}</option>
                   ))}
                 </select>
               </div>
@@ -100,19 +105,19 @@ export default function VaccineInfo(props: {
       </div>
       <div className="mb-4">
         <DataGrid
-          selectedCounty={selectedCounty}
+          selectedDistrict={selectedDistrict}
           hospitals={availableHospitals}
           buttonText={t('btn-getAppointment')}
           vaccineType={vaccineType}
         />
         <DataGrid
-          selectedCounty={selectedCounty}
+          selectedDistrict={selectedDistrict}
           hospitals={noDataHospitals}
           buttonText={t('btn-visitWebsite')}
           vaccineType={vaccineType}
         />
         <DataGrid
-          selectedCounty={selectedCounty}
+          selectedDistrict={selectedDistrict}
           hospitals={unavailableHospitals}
           buttonText={t('btn-visitWebsite')}
           vaccineType={vaccineType}

--- a/frontend/Components/VaccineInfo.jsx
+++ b/frontend/Components/VaccineInfo.jsx
@@ -9,37 +9,35 @@ import type { Hospital } from '../Types/Hospital';
 import type { Location } from '../Types/Location';
 import type { VaccineType } from '../Types/VaccineType';
 
-export default function VaccineInfo(
-  props: { rows: Array<Hospital>, vaccineType: VaccineType },
-): React.Node {
-  const { rows, vaccineType } = props;
+export default function VaccineInfo(props: {
+  rows: Array<Hospital>,
+  vaccineType: VaccineType,
+  selectedLocation: Location,
+  setLocation: (Location) => void,
+}): React.Node {
+  const {
+    rows, vaccineType, selectedLocation, setLocation,
+  } = props;
   const { t } = useTranslation('dataGrid');
   const [tNav] = useTranslation('nav');
 
-  const availableHospitals = rows.filter((row) => getAvailability(row, vaccineType) === 'Available');
-  const unavailableHospitals = rows.filter((row) => getAvailability(row, vaccineType) === 'Unavailable');
-  const noDataHospitals = rows.filter((row) => getAvailability(row, vaccineType) === 'No data');
+  const availableHospitals = rows.filter(
+    (row) => getAvailability(row, vaccineType) === 'Available',
+  );
+  const unavailableHospitals = rows.filter(
+    (row) => getAvailability(row, vaccineType) === 'Unavailable',
+  );
+  const noDataHospitals = rows.filter(
+    (row) => getAvailability(row, vaccineType) === 'No data',
+  );
 
-  const [selectedLocation, setLocation] = React.useState('臺北市');
   const [selectedCounty, setCounty] = React.useState('null');
 
   if (rows.length === 0) {
-    return (
-      <div>獲取資料中...</div>
-    );
+    return <div>獲取資料中...</div>;
   }
 
-  const countiesGroupByCity = rows.reduce((byCity: { [Location]: string[] }, hospital) => {
-    if (hospital.location in byCity) {
-      if (byCity[hospital.location].indexOf(hospital.county) === -1) {
-        byCity[hospital.location].push(hospital.county);
-      }
-      return byCity;
-    }
-    const newLocation = {};
-    newLocation[hospital.location] = [hospital.county];
-    return { ...byCity, ...newLocation };
-  }, {});
+  const counties = new Set(rows.map((hospital) => hospital.county));
   function changeLocations(event) {
     setLocation(event.target.value);
     setCounty('null');
@@ -50,36 +48,50 @@ export default function VaccineInfo(
 
   return (
     <div>
-      <div style={{ height: '80vh' }} className="d-flex justify-content-center align-items-center text-center">
+      <div
+        style={{ height: '80vh' }}
+        className="d-flex justify-content-center align-items-center text-center"
+      >
         <div className="flex-fill">
           <h3 className="mb-4">💉</h3>
           <h1>{tNav('txt-title')}</h1>
           <p>1922 以外的預約方式整理</p>
           <p>Vaccination sites & where to make reservations</p>
-          <button type="button" className="btn btn-secondary" data-bs-toggle="modal" data-bs-target="#InfoModal">資訊陸續更新中！</button>
+          <button
+            type="button"
+            className="btn btn-secondary"
+            data-bs-toggle="modal"
+            data-bs-target="#InfoModal"
+          >
+            資訊陸續更新中！
+          </button>
           <div className="mt-5">
             <h3>選擇施打點所在縣市</h3>
             <p>請問您想搜尋哪一個縣市的施打點？</p>
             <div className="row justify-content-center">
               <div className="col-md-4 mb-2">
-                <select name="locations" className="form-select" onChange={changeLocations} value={selectedLocation}>
-                  {
-                    Object.keys(CITY_LIST).map((location) => (
-                      <option value={location}>{location}</option>
-                    ))
-                  }
+                <select
+                  name="locations"
+                  className="form-select"
+                  onChange={changeLocations}
+                  value={selectedLocation}
+                >
+                  {Object.keys(CITY_LIST).map((location) => (
+                    <option value={location}>{location}</option>
+                  ))}
                 </select>
               </div>
               <div className="col-md-4 mb-2">
-                <select name="county" className="form-select" onChange={changeCounty} value={selectedCounty}>
+                <select
+                  name="county"
+                  className="form-select"
+                  onChange={changeCounty}
+                  value={selectedCounty}
+                >
                   <option value="null">全部地區</option>
-                  {
-                    countiesGroupByCity[selectedLocation].map(
-                      (county) => (
-                        <option value={county}>{county}</option>
-                      ),
-                    )
-                  }
+                  {[...counties].map((county) => (
+                    <option value={county}>{county}</option>
+                  ))}
                 </select>
               </div>
             </div>
@@ -88,21 +100,18 @@ export default function VaccineInfo(
       </div>
       <div className="mb-4">
         <DataGrid
-          selectedLocation={selectedLocation}
           selectedCounty={selectedCounty}
           hospitals={availableHospitals}
           buttonText={t('btn-getAppointment')}
           vaccineType={vaccineType}
         />
         <DataGrid
-          selectedLocation={selectedLocation}
           selectedCounty={selectedCounty}
           hospitals={noDataHospitals}
           buttonText={t('btn-visitWebsite')}
           vaccineType={vaccineType}
         />
         <DataGrid
-          selectedLocation={selectedLocation}
           selectedCounty={selectedCounty}
           hospitals={unavailableHospitals}
           buttonText={t('btn-visitWebsite')}

--- a/frontend/Components/VaccineInfo/Card.jsx
+++ b/frontend/Components/VaccineInfo/Card.jsx
@@ -34,7 +34,7 @@ export default function Card(props: {
   buttonText: string,
   department: string,
   location: Location,
-  county: string,
+  district: string,
   name: string,
   phone: string,
   website: string,
@@ -45,7 +45,7 @@ export default function Card(props: {
     buttonText,
     department,
     location,
-    county,
+    district,
     name,
     phone,
     website,
@@ -63,19 +63,26 @@ export default function Card(props: {
           <span className="badge bg-dark text-light me-1">
             {getLocationName(location, cityT)}
           </span>
-          <span className="badge bg-dark text-light me-1">
-            {county}
-          </span>
+          <span className="badge bg-dark text-light me-1">{district}</span>
         </p>
         <h4 className="card-title">{name}</h4>
         <h6 className="card-subtitle mb-2 text-muted">{address}</h6>
         <p className="card-text">{department}</p>
         <p className="card-text">{phone}</p>
         <div className="d-grid mt-auto">
-          {
-            website != null ? <a href={website} className="btn btn-primary mb-1" target="_blank" rel="noreferrer">{buttonText}</a> : null
-          }
-          <a href={`tel:${phone}`} className="btn btn-primary mb-1 d-md-none">電話預約</a>
+          {website != null ? (
+            <a
+              href={website}
+              className="btn btn-primary mb-1"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {buttonText}
+            </a>
+          ) : null}
+          <a href={`tel:${phone}`} className="btn btn-primary mb-1 d-md-none">
+            電話預約
+          </a>
         </div>
       </div>
     </div>

--- a/frontend/Components/VaccineInfo/Cards.jsx
+++ b/frontend/Components/VaccineInfo/Cards.jsx
@@ -6,9 +6,11 @@ import { getAvailability } from '../../Types/Hospital';
 import type { Hospital } from '../../Types/Hospital';
 import type { VaccineType } from '../../Types/VaccineType';
 
-export default function Cards(
-  props: { hospitals: Hospital[], vaccineType: VaccineType, buttonText: string},
-): React.Node {
+export default function Cards(props: {
+  hospitals: Hospital[],
+  vaccineType: VaccineType,
+  buttonText: string,
+}): React.Node {
   const { hospitals, buttonText, vaccineType } = props;
 
   return hospitals.map((hospital) => (
@@ -19,7 +21,7 @@ export default function Cards(
         buttonText={buttonText}
         department={hospital.department}
         location={hospital.location}
-        county={hospital.county}
+        district={hospital.district}
         name={hospital.name}
         phone={hospital.phone}
         website={hospital.website}

--- a/frontend/Components/VaccineInfo/DataGrid.jsx
+++ b/frontend/Components/VaccineInfo/DataGrid.jsx
@@ -11,10 +11,10 @@ export default function DataGrid(props: {
   hospitals: Hospital[],
   buttonText: string,
   vaccineType: VaccineType,
-  selectedCounty: string,
+  selectedDistrict: ?string,
 }): React.Node {
   const {
-    hospitals, buttonText, vaccineType, selectedCounty,
+    hospitals, buttonText, vaccineType, selectedDistrict,
   } = props;
 
   if (hospitals.length === 0) {
@@ -41,7 +41,8 @@ export default function DataGrid(props: {
         hospitals
           .filter((hospital) => hospital !== undefined)
           .filter(
-            (hospital) => selectedCounty === 'null' || hospital.county === selectedCounty,
+            (hospital) => selectedDistrict === null
+              || hospital.district === selectedDistrict,
           ),
       )}
     </>

--- a/frontend/Components/VaccineInfo/DataGrid.jsx
+++ b/frontend/Components/VaccineInfo/DataGrid.jsx
@@ -5,51 +5,45 @@ import * as React from 'react';
 import Cards from './Cards';
 
 import type { Hospital } from '../../Types/Hospital';
-import type { Location } from '../../Types/Location';
 import type { VaccineType } from '../../Types/VaccineType';
 
 export default function DataGrid(props: {
   hospitals: Hospital[],
   buttonText: string,
   vaccineType: VaccineType,
-  selectedLocation: string,
-  selectedCounty: string
+  selectedCounty: string,
 }): React.Node {
   const {
-    hospitals, buttonText, vaccineType, selectedLocation, selectedCounty,
+    hospitals, buttonText, vaccineType, selectedCounty,
   } = props;
 
-  const hospitalsByCity = hospitals.reduce((byCity: { [Location]: Hospital[] }, hospital) => {
-    if (hospital.location in byCity) {
-      byCity[hospital.location].push(hospital);
-      return byCity;
-    }
-
-    const newLocation = {};
-    newLocation[hospital.location] = [hospital];
-    return { ...byCity, ...newLocation };
-  }, {});
-
   if (hospitals.length === 0) {
-    return (
-      <div> </div>
-    );
+    return <div> </div>;
   }
 
-  const makeCardGrid: (Hospital[]) =>
-  React.Node = (localHospitals) => (
+  const makeCardGrid: (Hospital[]) => React.Node = (localHospitals) => (
     <div className="row row-cols-1 row-cols-md-3 g-3">
-      <Cards hospitals={localHospitals} buttonText={buttonText} vaccineType={vaccineType} />
+      <Cards
+        hospitals={localHospitals}
+        buttonText={buttonText}
+        vaccineType={vaccineType}
+      />
     </div>
   );
 
-  return (hospitals.length <= 20 ? makeCardGrid(hospitals)
-    : (
-      <>
-        {/* $FlowFixMe: Casting from enum to string. */}
-        {/* $FlowFixMe: Casting from a string to an Enum. */}
-        {makeCardGrid(hospitalsByCity[selectedLocation].filter((hospital) => hospital !== undefined).filter((hospital) => (selectedCounty === 'null') || (hospital.county === selectedCounty)))}
-      </>
-    )
+  return hospitals.length <= 20 ? (
+    makeCardGrid(hospitals)
+  ) : (
+    <>
+      {/* $FlowFixMe: Casting from enum to string. */}
+      {/* $FlowFixMe: Casting from a string to an Enum. */}
+      {makeCardGrid(
+        hospitals
+          .filter((hospital) => hospital !== undefined)
+          .filter(
+            (hospital) => selectedCounty === 'null' || hospital.county === selectedCounty,
+          ),
+      )}
+    </>
   );
 }

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -5,17 +5,28 @@ import VaccineInfo from '../Components/VaccineInfo';
 export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
   const apiURL = process.env.API_URL || '';
+  const [selectedLocation, setLocation] = React.useState('臺北市');
   React.useEffect(() => {
-    const url = '/government_paid_hospitals';
-    fetch(apiURL + url).then((data) => data.json()).then((res) => setRows(res));
-  }, []); // Empty list makes this useEffect similar to componentDidMount();
+    setRows([]);
+    const url = new URL(`${apiURL}/government_paid_hospitals`);
+    url.searchParams.set('city', selectedLocation);
+    fetch(url)
+      .then((data) => data.json())
+      .then((res) => setRows(res));
+  }, [selectedLocation]); // Run effect when city is changed
 
   return (
     <>
-      <VaccineInfo
-        vaccineType="GovernmentPaid"
-        rows={rows}
-      />
+      {rows.length === 0 ? (
+        <div>Loading</div>
+      ) : (
+        <VaccineInfo
+          vaccineType="GovernmentPaid"
+          rows={rows}
+          selectedLocation={selectedLocation}
+          setLocation={setLocation}
+        />
+      )}
     </>
   );
 }

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -1,18 +1,42 @@
 // @flow
-import * as React from 'react';
-import VaccineInfo from '../Components/VaccineInfo';
+import * as React from "react";
+import VaccineInfo from "../Components/VaccineInfo";
+
+import type { Hospital } from "../Types/Hospital";
+
+/**
+ * Parses untyped data from our server and ensures it fits the
+ * type declared in ../Types/Hospital.
+ */
+function refineUntypedHospital(rawData: any): Hospital {
+  return {
+    address: rawData.address,
+    department: rawData.department,
+    governmentPaidAvailability: rawData.governmentPaidAvailability,
+    hospitalId: rawData.hospitalId,
+    location: rawData.location,
+    district: rawData.district,
+    name: rawData.name,
+    phone: rawData.phone,
+    selfPaidAvailability: rawData.selfPaidAvailability,
+    website: rawData.website,
+  };
+}
 
 export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
-  const apiURL = process.env.API_URL || '';
-  const [selectedLocation, setLocation] = React.useState('臺北市');
+  const apiURL = process.env.API_URL || "";
+  const [selectedLocation, setLocation] = React.useState("臺北市");
+  const [selectedDistrict, setDistrict] = React.useState(null);
   React.useEffect(() => {
     setRows([]);
     const url = new URL(`${apiURL}/government_paid_hospitals`);
-    url.searchParams.set('city', selectedLocation);
+    url.searchParams.set("city", selectedLocation);
     fetch(url)
       .then((data) => data.json())
-      .then((res) => setRows(res));
+      .then((res) => {
+        setRows(res.map((row) => refineUntypedHospital(row)));
+      });
   }, [selectedLocation]); // Run effect when city is changed
 
   return (
@@ -25,6 +49,8 @@ export default function Home(): React.Node {
           rows={rows}
           selectedLocation={selectedLocation}
           setLocation={setLocation}
+          selectedDistrict={selectedDistrict}
+          setDistrict={setDistrict}
         />
       )}
     </>

--- a/frontend/Types/Hospital.js
+++ b/frontend/Types/Hospital.js
@@ -3,20 +3,24 @@ import type { Availability } from './Availability';
 import type { Location } from './Location';
 import type { VaccineType } from './VaccineType';
 
-export type Hospital = {
-    address: string,
-    department: string,
-    governmentPaidAvailability: Availability,
-    hospitalId: number,
-    location: Location,
-    county: string,
-    name: string,
-    phone: string,
-    selfPaidAvailability: Availability,
-    website: string,
-  };
+export type Hospital = {|
+  address: string,
+  department: string,
+  governmentPaidAvailability: Availability,
+  hospitalId: number,
+  location: Location,
+  district: string,
+  name: string,
+  phone: string,
+  selfPaidAvailability: Availability,
+  website: string,
+|};
 
-export function getAvailability(hospital: Hospital, vaccineType: VaccineType): Availability {
+export function getAvailability(
+  hospital: Hospital,
+  vaccineType: VaccineType,
+): Availability {
   return vaccineType === 'SelfPaid'
-    ? hospital.selfPaidAvailability : hospital.governmentPaidAvailability;
+    ? hospital.selfPaidAvailability
+    : hospital.governmentPaidAvailability;
 }


### PR DESCRIPTION
# Context
- We want to make the website faster. Before thinking about caching, one thing we can do is reduce the payload that we are requesting from AirTable. 

# This PR
- Rather than requesting data from all hospitals at once, this PR queries AirTable by each city instead.

# Performance Measurement
## Methodology
By inserting `time.time()` calls before and after each request, we can time how long it's taking for our server to respond to requests to `/government_paid_hospitals`. 
```
# pyre-fixme[56]: Decorator async types are not type-checked.
@app.route("/government_paid_hospitals")
async def government_paid_hospitals() -> wrappers.Response:
    start_time = time.time()
    city: str = request.args.get("city")
    data = await get_hospitals_from_airtable("", city)
    response = app.response_class(
        response=json.dumps(data),
        status=200,
        mimetype="application/json",
    )
    end_time = time.time()
    print(f"Execution time {end_time - start_time}")
    return response
```

Time (seconds)

|  | Test 1 | Test 2 | Test 3 | Test 4 | Test 5 | Average
|-|-|-|-|-|-|-|
| Before | 13.18s | 13.04s | 14.93s | 13.02 | 13.72 | 13.59 
| After | 4.83s | 6.08s | 4.25s | 2.72 | 2.95 | 4.17s

**Total request response time improvement: 13.59-4.17 = 9.42 seconds. (3.25x speedup)**

# Test Plan
- [X] yarn lint, yarn tc and yarn test are passing
- [X] Website loads successfully. 
![image](https://user-images.githubusercontent.com/8745371/126029431-6f94382a-81f6-4003-beb2-6c8daa7dc5cb.png)

- [X] Website can switch between cities

https://user-images.githubusercontent.com/8745371/126029568-e06820be-36a1-4cb1-a3cf-283b82f2c607.mp4

- [X] Website can switch between counties

https://user-images.githubusercontent.com/8745371/126029606-40ba0e7b-5c50-4894-83a7-aef7d461a588.mp4

