### PR TITLE
[4][EASY] Rename 'county' to 'district'. Lift state hook up.

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -142,7 +142,7 @@ def parse_airtable_json_for_hospital(raw_data: Dict[str, Any]) -> Hospital:
         "governmentPaidAvailability": AppointmentAvailability.NO_DATA,
         "hospitalId": "0",
         "location": raw_data["施打站縣市（自動）"],
-        "county": raw_data.get("施打站行政區（自動）", "無資料"),
+        "district": raw_data.get("施打站行政區（自動）", "無資料"),
         "name": raw_data["施打站全稱（自動）"],
         "phone": raw_data.get("預約電話（自動）", "無資料"),
         "website": raw_data.get("實際預約網址（手動）", raw_data.get("官方提供網址（自動）", None)),

--- a/backend/hospital_types.py
+++ b/backend/hospital_types.py
@@ -17,7 +17,7 @@ class Hospital(TypedDict):
     governmentPaidAvailability: AppointmentAvailability
     hospitalId: HospitalID
     location: str
-    county: str
+    district: str
     name: str
     phone: str
     selfPaidAvailability: AppointmentAvailability

--- a/backend/migrate.py
+++ b/backend/migrate.py
@@ -21,7 +21,7 @@ def main() -> None:
             "governmentPaidAvailability": AppointmentAvailability.NO_DATA,
             "hospitalId": row["編號"],
             "location": row["縣市"],
-            "county": "",
+            "district": "",
             "name": row["醫院名稱"],
             "phone": row["電話"],
             "website": row["Website"],

--- a/frontend/Components/VaccineInfo.jsx
+++ b/frontend/Components/VaccineInfo.jsx
@@ -1,60 +1,65 @@
 // @flow
-import * as React from 'react';
-import { useTranslation } from 'react-i18next';
-import DataGrid from './VaccineInfo/DataGrid';
-import { getAvailability } from '../Types/Hospital';
-import { CITY_LIST } from '../Types/Location';
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import DataGrid from "./VaccineInfo/DataGrid";
+import { getAvailability } from "../Types/Hospital";
+import { CITY_LIST } from "../Types/Location";
 
-import type { Hospital } from '../Types/Hospital';
-import type { Location } from '../Types/Location';
-import type { VaccineType } from '../Types/VaccineType';
+import type { Hospital } from "../Types/Hospital";
+import type { Location } from "../Types/Location";
+import type { VaccineType } from "../Types/VaccineType";
 
 export default function VaccineInfo(props: {
   rows: Array<Hospital>,
   vaccineType: VaccineType,
   selectedLocation: Location,
   setLocation: (Location) => void,
+  selectedDistrict: ?string,
+  setDistrict: (?string) => void,
 }): React.Node {
   const {
-    rows, vaccineType, selectedLocation, setLocation,
+    rows,
+    vaccineType,
+    selectedLocation,
+    setLocation,
+    selectedDistrict,
+    setDistrict,
   } = props;
-  const { t } = useTranslation('dataGrid');
-  const [tNav] = useTranslation('nav');
+  const { t } = useTranslation("dataGrid");
+  const [tNav] = useTranslation("nav");
 
   const availableHospitals = rows.filter(
-    (row) => getAvailability(row, vaccineType) === 'Available',
+    (row) => getAvailability(row, vaccineType) === "Available"
   );
   const unavailableHospitals = rows.filter(
-    (row) => getAvailability(row, vaccineType) === 'Unavailable',
+    (row) => getAvailability(row, vaccineType) === "Unavailable"
   );
   const noDataHospitals = rows.filter(
-    (row) => getAvailability(row, vaccineType) === 'No data',
+    (row) => getAvailability(row, vaccineType) === "No data"
   );
-
-  const [selectedCounty, setCounty] = React.useState('null');
 
   if (rows.length === 0) {
     return <div>獲取資料中...</div>;
   }
 
-  const counties = new Set(rows.map((hospital) => hospital.county));
+  const districts = new Set(rows.map((hospital) => hospital.district));
   function changeLocations(event) {
     setLocation(event.target.value);
-    setCounty('null');
+    setDistrict(null);
   }
-  function changeCounty(event) {
-    setCounty(event.target.value);
+  function changeDistrict(event) {
+    setDistrict(event.target.value);
   }
 
   return (
     <div>
       <div
-        style={{ height: '80vh' }}
+        style={{ height: "80vh" }}
         className="d-flex justify-content-center align-items-center text-center"
       >
         <div className="flex-fill">
           <h3 className="mb-4">💉</h3>
-          <h1>{tNav('txt-title')}</h1>
+          <h1>{tNav("txt-title")}</h1>
           <p>1922 以外的預約方式整理</p>
           <p>Vaccination sites & where to make reservations</p>
           <button
@@ -85,12 +90,12 @@ export default function VaccineInfo(props: {
                 <select
                   name="county"
                   className="form-select"
-                  onChange={changeCounty}
-                  value={selectedCounty}
+                  onChange={changeDistrict}
+                  value={selectedDistrict}
                 >
                   <option value="null">全部地區</option>
-                  {[...counties].map((county) => (
-                    <option value={county}>{county}</option>
+                  {[...districts].map((district) => (
+                    <option value={district}>{district}</option>
                   ))}
                 </select>
               </div>
@@ -100,21 +105,21 @@ export default function VaccineInfo(props: {
       </div>
       <div className="mb-4">
         <DataGrid
-          selectedCounty={selectedCounty}
+          selectedDistrict={selectedDistrict}
           hospitals={availableHospitals}
-          buttonText={t('btn-getAppointment')}
+          buttonText={t("btn-getAppointment")}
           vaccineType={vaccineType}
         />
         <DataGrid
-          selectedCounty={selectedCounty}
+          selectedDistrict={selectedDistrict}
           hospitals={noDataHospitals}
-          buttonText={t('btn-visitWebsite')}
+          buttonText={t("btn-visitWebsite")}
           vaccineType={vaccineType}
         />
         <DataGrid
-          selectedCounty={selectedCounty}
+          selectedDistrict={selectedDistrict}
           hospitals={unavailableHospitals}
-          buttonText={t('btn-visitWebsite')}
+          buttonText={t("btn-visitWebsite")}
           vaccineType={vaccineType}
         />
       </div>

--- a/frontend/Components/VaccineInfo.jsx
+++ b/frontend/Components/VaccineInfo.jsx
@@ -1,13 +1,13 @@
 // @flow
-import * as React from "react";
-import { useTranslation } from "react-i18next";
-import DataGrid from "./VaccineInfo/DataGrid";
-import { getAvailability } from "../Types/Hospital";
-import { CITY_LIST } from "../Types/Location";
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import DataGrid from './VaccineInfo/DataGrid';
+import { getAvailability } from '../Types/Hospital';
+import { CITY_LIST } from '../Types/Location';
 
-import type { Hospital } from "../Types/Hospital";
-import type { Location } from "../Types/Location";
-import type { VaccineType } from "../Types/VaccineType";
+import type { Hospital } from '../Types/Hospital';
+import type { Location } from '../Types/Location';
+import type { VaccineType } from '../Types/VaccineType';
 
 export default function VaccineInfo(props: {
   rows: Array<Hospital>,
@@ -25,17 +25,17 @@ export default function VaccineInfo(props: {
     selectedDistrict,
     setDistrict,
   } = props;
-  const { t } = useTranslation("dataGrid");
-  const [tNav] = useTranslation("nav");
+  const { t } = useTranslation('dataGrid');
+  const [tNav] = useTranslation('nav');
 
   const availableHospitals = rows.filter(
-    (row) => getAvailability(row, vaccineType) === "Available"
+    (row) => getAvailability(row, vaccineType) === 'Available',
   );
   const unavailableHospitals = rows.filter(
-    (row) => getAvailability(row, vaccineType) === "Unavailable"
+    (row) => getAvailability(row, vaccineType) === 'Unavailable',
   );
   const noDataHospitals = rows.filter(
-    (row) => getAvailability(row, vaccineType) === "No data"
+    (row) => getAvailability(row, vaccineType) === 'No data',
   );
 
   if (rows.length === 0) {
@@ -54,12 +54,12 @@ export default function VaccineInfo(props: {
   return (
     <div>
       <div
-        style={{ height: "80vh" }}
+        style={{ height: '80vh' }}
         className="d-flex justify-content-center align-items-center text-center"
       >
         <div className="flex-fill">
           <h3 className="mb-4">💉</h3>
-          <h1>{tNav("txt-title")}</h1>
+          <h1>{tNav('txt-title')}</h1>
           <p>1922 以外的預約方式整理</p>
           <p>Vaccination sites & where to make reservations</p>
           <button
@@ -107,19 +107,19 @@ export default function VaccineInfo(props: {
         <DataGrid
           selectedDistrict={selectedDistrict}
           hospitals={availableHospitals}
-          buttonText={t("btn-getAppointment")}
+          buttonText={t('btn-getAppointment')}
           vaccineType={vaccineType}
         />
         <DataGrid
           selectedDistrict={selectedDistrict}
           hospitals={noDataHospitals}
-          buttonText={t("btn-visitWebsite")}
+          buttonText={t('btn-visitWebsite')}
           vaccineType={vaccineType}
         />
         <DataGrid
           selectedDistrict={selectedDistrict}
           hospitals={unavailableHospitals}
-          buttonText={t("btn-visitWebsite")}
+          buttonText={t('btn-visitWebsite')}
           vaccineType={vaccineType}
         />
       </div>

--- a/frontend/Components/VaccineInfo/Card.jsx
+++ b/frontend/Components/VaccineInfo/Card.jsx
@@ -1,30 +1,30 @@
 // @flow
-import * as React from 'react';
-import { useTranslation } from 'react-i18next';
-import { getLocationName } from '../../Types/Location';
-import type { Availability } from '../../Types/Availability';
-import type { Location } from '../../Types/Location';
+import * as React from "react";
+import { useTranslation } from "react-i18next";
+import { getLocationName } from "../../Types/Location";
+import type { Availability } from "../../Types/Availability";
+import type { Location } from "../../Types/Location";
 
 function getBadgeClassname(availability: Availability): string {
   switch (availability) {
-    case 'Available':
-      return 'badge bg-success me-1 d-none';
-    case 'Unavailable':
-      return 'badge bg-danger me-1 d-none';
+    case "Available":
+      return "badge bg-success me-1 d-none";
+    case "Unavailable":
+      return "badge bg-danger me-1 d-none";
     default:
-      return 'badge bg-light text-dark me-1 d-none';
+      return "badge bg-light text-dark me-1 d-none";
   }
 }
 
 function getBadgeText(availability: Availability, t): string {
   switch (availability) {
-    case 'Available':
-      return t('txt-available');
-    case 'Unavailable':
-      return t('txt-unavailable');
-    case 'No Data':
+    case "Available":
+      return t("txt-available");
+    case "Unavailable":
+      return t("txt-unavailable");
+    case "No Data":
     default:
-      return t('txt-noData');
+      return t("txt-noData");
   }
 }
 
@@ -34,7 +34,7 @@ export default function Card(props: {
   buttonText: string,
   department: string,
   location: Location,
-  county: string,
+  district: string,
   name: string,
   phone: string,
   website: string,
@@ -45,14 +45,14 @@ export default function Card(props: {
     buttonText,
     department,
     location,
-    county,
+    district,
     name,
     phone,
     website,
   } = props;
 
-  const [cardT] = useTranslation('card');
-  const [cityT] = useTranslation('city');
+  const [cardT] = useTranslation("card");
+  const [cityT] = useTranslation("city");
   return (
     <div className="card">
       <div className="card-body d-flex flex-column">
@@ -63,19 +63,26 @@ export default function Card(props: {
           <span className="badge bg-dark text-light me-1">
             {getLocationName(location, cityT)}
           </span>
-          <span className="badge bg-dark text-light me-1">
-            {county}
-          </span>
+          <span className="badge bg-dark text-light me-1">{district}</span>
         </p>
         <h4 className="card-title">{name}</h4>
         <h6 className="card-subtitle mb-2 text-muted">{address}</h6>
         <p className="card-text">{department}</p>
         <p className="card-text">{phone}</p>
         <div className="d-grid mt-auto">
-          {
-            website != null ? <a href={website} className="btn btn-primary mb-1" target="_blank" rel="noreferrer">{buttonText}</a> : null
-          }
-          <a href={`tel:${phone}`} className="btn btn-primary mb-1 d-md-none">電話預約</a>
+          {website != null ? (
+            <a
+              href={website}
+              className="btn btn-primary mb-1"
+              target="_blank"
+              rel="noreferrer"
+            >
+              {buttonText}
+            </a>
+          ) : null}
+          <a href={`tel:${phone}`} className="btn btn-primary mb-1 d-md-none">
+            電話預約
+          </a>
         </div>
       </div>
     </div>

--- a/frontend/Components/VaccineInfo/Card.jsx
+++ b/frontend/Components/VaccineInfo/Card.jsx
@@ -1,30 +1,30 @@
 // @flow
-import * as React from "react";
-import { useTranslation } from "react-i18next";
-import { getLocationName } from "../../Types/Location";
-import type { Availability } from "../../Types/Availability";
-import type { Location } from "../../Types/Location";
+import * as React from 'react';
+import { useTranslation } from 'react-i18next';
+import { getLocationName } from '../../Types/Location';
+import type { Availability } from '../../Types/Availability';
+import type { Location } from '../../Types/Location';
 
 function getBadgeClassname(availability: Availability): string {
   switch (availability) {
-    case "Available":
-      return "badge bg-success me-1 d-none";
-    case "Unavailable":
-      return "badge bg-danger me-1 d-none";
+    case 'Available':
+      return 'badge bg-success me-1 d-none';
+    case 'Unavailable':
+      return 'badge bg-danger me-1 d-none';
     default:
-      return "badge bg-light text-dark me-1 d-none";
+      return 'badge bg-light text-dark me-1 d-none';
   }
 }
 
 function getBadgeText(availability: Availability, t): string {
   switch (availability) {
-    case "Available":
-      return t("txt-available");
-    case "Unavailable":
-      return t("txt-unavailable");
-    case "No Data":
+    case 'Available':
+      return t('txt-available');
+    case 'Unavailable':
+      return t('txt-unavailable');
+    case 'No Data':
     default:
-      return t("txt-noData");
+      return t('txt-noData');
   }
 }
 
@@ -51,8 +51,8 @@ export default function Card(props: {
     website,
   } = props;
 
-  const [cardT] = useTranslation("card");
-  const [cityT] = useTranslation("city");
+  const [cardT] = useTranslation('card');
+  const [cityT] = useTranslation('city');
   return (
     <div className="card">
       <div className="card-body d-flex flex-column">

--- a/frontend/Components/VaccineInfo/Cards.jsx
+++ b/frontend/Components/VaccineInfo/Cards.jsx
@@ -1,10 +1,10 @@
 // @flow
-import * as React from "react";
-import Card from "./Card";
-import { getAvailability } from "../../Types/Hospital";
+import * as React from 'react';
+import Card from './Card';
+import { getAvailability } from '../../Types/Hospital';
 
-import type { Hospital } from "../../Types/Hospital";
-import type { VaccineType } from "../../Types/VaccineType";
+import type { Hospital } from '../../Types/Hospital';
+import type { VaccineType } from '../../Types/VaccineType';
 
 export default function Cards(props: {
   hospitals: Hospital[],

--- a/frontend/Components/VaccineInfo/Cards.jsx
+++ b/frontend/Components/VaccineInfo/Cards.jsx
@@ -1,14 +1,16 @@
 // @flow
-import * as React from 'react';
-import Card from './Card';
-import { getAvailability } from '../../Types/Hospital';
+import * as React from "react";
+import Card from "./Card";
+import { getAvailability } from "../../Types/Hospital";
 
-import type { Hospital } from '../../Types/Hospital';
-import type { VaccineType } from '../../Types/VaccineType';
+import type { Hospital } from "../../Types/Hospital";
+import type { VaccineType } from "../../Types/VaccineType";
 
-export default function Cards(
-  props: { hospitals: Hospital[], vaccineType: VaccineType, buttonText: string},
-): React.Node {
+export default function Cards(props: {
+  hospitals: Hospital[],
+  vaccineType: VaccineType,
+  buttonText: string,
+}): React.Node {
   const { hospitals, buttonText, vaccineType } = props;
 
   return hospitals.map((hospital) => (
@@ -19,7 +21,7 @@ export default function Cards(
         buttonText={buttonText}
         department={hospital.department}
         location={hospital.location}
-        county={hospital.county}
+        district={hospital.district}
         name={hospital.name}
         phone={hospital.phone}
         website={hospital.website}

--- a/frontend/Components/VaccineInfo/DataGrid.jsx
+++ b/frontend/Components/VaccineInfo/DataGrid.jsx
@@ -1,11 +1,11 @@
 /* eslint-disable max-len */
 // @flow
 
-import * as React from "react";
-import Cards from "./Cards";
+import * as React from 'react';
+import Cards from './Cards';
 
-import type { Hospital } from "../../Types/Hospital";
-import type { VaccineType } from "../../Types/VaccineType";
+import type { Hospital } from '../../Types/Hospital';
+import type { VaccineType } from '../../Types/VaccineType';
 
 export default function DataGrid(props: {
   hospitals: Hospital[],
@@ -13,7 +13,9 @@ export default function DataGrid(props: {
   vaccineType: VaccineType,
   selectedDistrict: ?string,
 }): React.Node {
-  const { hospitals, buttonText, vaccineType, selectedDistrict } = props;
+  const {
+    hospitals, buttonText, vaccineType, selectedDistrict,
+  } = props;
 
   if (hospitals.length === 0) {
     return <div> </div>;
@@ -39,10 +41,9 @@ export default function DataGrid(props: {
         hospitals
           .filter((hospital) => hospital !== undefined)
           .filter(
-            (hospital) =>
-              selectedDistrict === null ||
-              hospital.district === selectedDistrict
-          )
+            (hospital) => selectedDistrict === null
+              || hospital.district === selectedDistrict,
+          ),
       )}
     </>
   );

--- a/frontend/Components/VaccineInfo/DataGrid.jsx
+++ b/frontend/Components/VaccineInfo/DataGrid.jsx
@@ -1,21 +1,19 @@
 /* eslint-disable max-len */
 // @flow
 
-import * as React from 'react';
-import Cards from './Cards';
+import * as React from "react";
+import Cards from "./Cards";
 
-import type { Hospital } from '../../Types/Hospital';
-import type { VaccineType } from '../../Types/VaccineType';
+import type { Hospital } from "../../Types/Hospital";
+import type { VaccineType } from "../../Types/VaccineType";
 
 export default function DataGrid(props: {
   hospitals: Hospital[],
   buttonText: string,
   vaccineType: VaccineType,
-  selectedCounty: string,
+  selectedDistrict: ?string,
 }): React.Node {
-  const {
-    hospitals, buttonText, vaccineType, selectedCounty,
-  } = props;
+  const { hospitals, buttonText, vaccineType, selectedDistrict } = props;
 
   if (hospitals.length === 0) {
     return <div> </div>;
@@ -41,8 +39,10 @@ export default function DataGrid(props: {
         hospitals
           .filter((hospital) => hospital !== undefined)
           .filter(
-            (hospital) => selectedCounty === 'null' || hospital.county === selectedCounty,
-          ),
+            (hospital) =>
+              selectedDistrict === null ||
+              hospital.district === selectedDistrict
+          )
       )}
     </>
   );

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -1,18 +1,42 @@
 // @flow
-import * as React from 'react';
-import VaccineInfo from '../Components/VaccineInfo';
+import * as React from "react";
+import VaccineInfo from "../Components/VaccineInfo";
+
+import type { Hospital } from "../Types/Hospital";
+
+/**
+ * Parses untyped data from our server and ensures it fits the
+ * type declared in ../Types/Hospital.
+ */
+function refineUntypedHospital(rawData: any): Hospital {
+  return {
+    address: rawData.address,
+    department: rawData.department,
+    governmentPaidAvailability: rawData.governmentPaidAvailability,
+    hospitalId: rawData.hospitalId,
+    location: rawData.location,
+    district: rawData.county,
+    name: rawData.name,
+    phone: rawData.phone,
+    selfPaidAvailability: rawData.selfPaidAvailability,
+    website: rawData.website,
+  };
+}
 
 export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
-  const apiURL = process.env.API_URL || '';
-  const [selectedLocation, setLocation] = React.useState('臺北市');
+  const apiURL = process.env.API_URL || "";
+  const [selectedLocation, setLocation] = React.useState("臺北市");
+  const [selectedDistrict, setDistrict] = React.useState(null);
   React.useEffect(() => {
     setRows([]);
     const url = new URL(`${apiURL}/government_paid_hospitals`);
-    url.searchParams.set('city', selectedLocation);
+    url.searchParams.set("city", selectedLocation);
     fetch(url)
       .then((data) => data.json())
-      .then((res) => setRows(res));
+      .then((res) => {
+        setRows(res.map((row) => refineUntypedHospital(row)));
+      });
   }, [selectedLocation]); // Run effect when city is changed
 
   return (
@@ -25,6 +49,8 @@ export default function Home(): React.Node {
           rows={rows}
           selectedLocation={selectedLocation}
           setLocation={setLocation}
+          selectedDistrict={selectedDistrict}
+          setDistrict={setDistrict}
         />
       )}
     </>

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -1,8 +1,8 @@
 // @flow
-import * as React from "react";
-import VaccineInfo from "../Components/VaccineInfo";
+import * as React from 'react';
+import VaccineInfo from '../Components/VaccineInfo';
 
-import type { Hospital } from "../Types/Hospital";
+import type { Hospital } from '../Types/Hospital';
 
 /**
  * Parses untyped data from our server and ensures it fits the
@@ -25,13 +25,13 @@ function refineUntypedHospital(rawData: any): Hospital {
 
 export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
-  const apiURL = process.env.API_URL || "";
-  const [selectedLocation, setLocation] = React.useState("臺北市");
+  const apiURL = process.env.API_URL || '';
+  const [selectedLocation, setLocation] = React.useState('臺北市');
   const [selectedDistrict, setDistrict] = React.useState(null);
   React.useEffect(() => {
     setRows([]);
     const url = new URL(`${apiURL}/government_paid_hospitals`);
-    url.searchParams.set("city", selectedLocation);
+    url.searchParams.set('city', selectedLocation);
     fetch(url)
       .then((data) => data.json())
       .then((res) => {

--- a/frontend/Pages/Home.jsx
+++ b/frontend/Pages/Home.jsx
@@ -1,8 +1,8 @@
 // @flow
-import * as React from 'react';
-import VaccineInfo from '../Components/VaccineInfo';
+import * as React from "react";
+import VaccineInfo from "../Components/VaccineInfo";
 
-import type { Hospital } from '../Types/Hospital';
+import type { Hospital } from "../Types/Hospital";
 
 /**
  * Parses untyped data from our server and ensures it fits the
@@ -15,7 +15,7 @@ function refineUntypedHospital(rawData: any): Hospital {
     governmentPaidAvailability: rawData.governmentPaidAvailability,
     hospitalId: rawData.hospitalId,
     location: rawData.location,
-    district: rawData.county,
+    district: rawData.district,
     name: rawData.name,
     phone: rawData.phone,
     selfPaidAvailability: rawData.selfPaidAvailability,
@@ -25,13 +25,13 @@ function refineUntypedHospital(rawData: any): Hospital {
 
 export default function Home(): React.Node {
   const [rows, setRows] = React.useState([]);
-  const apiURL = process.env.API_URL || '';
-  const [selectedLocation, setLocation] = React.useState('臺北市');
+  const apiURL = process.env.API_URL || "";
+  const [selectedLocation, setLocation] = React.useState("臺北市");
   const [selectedDistrict, setDistrict] = React.useState(null);
   React.useEffect(() => {
     setRows([]);
     const url = new URL(`${apiURL}/government_paid_hospitals`);
-    url.searchParams.set('city', selectedLocation);
+    url.searchParams.set("city", selectedLocation);
     fetch(url)
       .then((data) => data.json())
       .then((res) => {

--- a/frontend/Types/Hospital.js
+++ b/frontend/Types/Hospital.js
@@ -1,22 +1,26 @@
 // @flow
-import type { Availability } from './Availability';
-import type { Location } from './Location';
-import type { VaccineType } from './VaccineType';
+import type { Availability } from "./Availability";
+import type { Location } from "./Location";
+import type { VaccineType } from "./VaccineType";
 
-export type Hospital = {
-    address: string,
-    department: string,
-    governmentPaidAvailability: Availability,
-    hospitalId: number,
-    location: Location,
-    county: string,
-    name: string,
-    phone: string,
-    selfPaidAvailability: Availability,
-    website: string,
-  };
+export type Hospital = {|
+  address: string,
+  department: string,
+  governmentPaidAvailability: Availability,
+  hospitalId: number,
+  location: Location,
+  district: string,
+  name: string,
+  phone: string,
+  selfPaidAvailability: Availability,
+  website: string,
+|};
 
-export function getAvailability(hospital: Hospital, vaccineType: VaccineType): Availability {
-  return vaccineType === 'SelfPaid'
-    ? hospital.selfPaidAvailability : hospital.governmentPaidAvailability;
+export function getAvailability(
+  hospital: Hospital,
+  vaccineType: VaccineType
+): Availability {
+  return vaccineType === "SelfPaid"
+    ? hospital.selfPaidAvailability
+    : hospital.governmentPaidAvailability;
 }

--- a/frontend/Types/Hospital.js
+++ b/frontend/Types/Hospital.js
@@ -1,7 +1,7 @@
 // @flow
-import type { Availability } from "./Availability";
-import type { Location } from "./Location";
-import type { VaccineType } from "./VaccineType";
+import type { Availability } from './Availability';
+import type { Location } from './Location';
+import type { VaccineType } from './VaccineType';
 
 export type Hospital = {|
   address: string,
@@ -18,9 +18,9 @@ export type Hospital = {|
 
 export function getAvailability(
   hospital: Hospital,
-  vaccineType: VaccineType
+  vaccineType: VaccineType,
 ): Availability {
-  return vaccineType === "SelfPaid"
+  return vaccineType === 'SelfPaid'
     ? hospital.selfPaidAvailability
     : hospital.governmentPaidAvailability;
 }


### PR DESCRIPTION
# Context
- Currently this is called 'county'. This is confusing because it actually refers to 行政區, which means district. 

# This PR
- Renames county to district. 
- Lifts the `setDistrict` and `selectedDistrict` state to `Home.jsx`, to anticipate moving them into request URL. 

# Test Plan
*Confirm switching counties still works.*

https://user-images.githubusercontent.com/8745371/126030979-ccf1bd5a-f8d3-429b-853f-5d17744f6c32.mp4

